### PR TITLE
Update slips.xml to reflect Oct. 2025 Retail. No version change.

### DIFF
--- a/build/resources/findall/slips.xml
+++ b/build/resources/findall/slips.xml
@@ -1,3813 +1,4093 @@
 <slips>
-    <slip id="29312">
-        <item offset="0" id="16084" /> <!--Ares' Mask-->
-        <item offset="1" id="14546" /> <!--Ares' Cuirass-->
-        <item offset="2" id="14961" /> <!--Ares' Gauntlets-->
-        <item offset="3" id="15625" /> <!--Ares' Flanchard-->
-        <item offset="4" id="15711" /> <!--Ares' Sollerets-->
-        <item offset="5" id="16085" /> <!--Enyo's Mask-->
-        <item offset="6" id="14547" /> <!--Enyo's Brstplate-->
-        <item offset="7" id="14962" /> <!--Enyo's Gauntlets-->
-        <item offset="8" id="15626" /> <!--Enyo's Cuisses-->
-        <item offset="9" id="15712" /> <!--Enyo's Leggings-->
-        <item offset="10" id="16086" /> <!--Phobos's Mask-->
-        <item offset="11" id="14548" /> <!--Phobos's Cuirass-->
-        <item offset="12" id="14963" /> <!--Phobos's Gnt.-->
-        <item offset="13" id="15627" /> <!--Phobos's Cuisses-->
-        <item offset="14" id="15713" /> <!--Phobos's Sabat.-->
-        <item offset="15" id="16087" /> <!--Deimos's Mask-->
-        <item offset="16" id="14549" /> <!--Deimos's Cuirass-->
-        <item offset="17" id="14964" /> <!--Deimos's Gnt.-->
-        <item offset="18" id="15628" /> <!--Deimos's Cuisses-->
-        <item offset="19" id="15714" /> <!--Deimos's Leggings-->
-        <item offset="20" id="16088" /> <!--Skadi's Visor-->
-        <item offset="21" id="14550" /> <!--Skadi's Cuirie-->
-        <item offset="22" id="14965" /> <!--Skadi's Bazubands-->
-        <item offset="23" id="15629" /> <!--Skadi's Chausses-->
-        <item offset="24" id="15715" /> <!--Skadi's Jambeaux-->
-        <item offset="25" id="16089" /> <!--Njord's Mask-->
-        <item offset="26" id="14551" /> <!--Njord's Jerkin-->
-        <item offset="27" id="14966" /> <!--Njord's Gloves-->
-        <item offset="28" id="15630" /> <!--Njord's Trousers-->
-        <item offset="29" id="15716" /> <!--Njord's Ledelsens-->
-        <item offset="30" id="16090" /> <!--Freyr's Mask-->
-        <item offset="31" id="14552" /> <!--Freyr's Jerkin-->
-        <item offset="32" id="14967" /> <!--Freyr's Gloves-->
-        <item offset="33" id="15631" /> <!--Freyr's Trousers-->
-        <item offset="34" id="15717" /> <!--Freyr's Ledelsens-->
-        <item offset="35" id="16091" /> <!--Freya's Mask-->
-        <item offset="36" id="14553" /> <!--Freya's Jerkin-->
-        <item offset="37" id="14968" /> <!--Freya's Gloves-->
-        <item offset="38" id="15632" /> <!--Freya's Trousers-->
-        <item offset="39" id="15718" /> <!--Freya's Ledelsens-->
-        <item offset="40" id="16092" /> <!--Usukane Somen-->
-        <item offset="41" id="14554" /> <!--Usukane Haramaki-->
-        <item offset="42" id="14969" /> <!--Usukane Gote-->
-        <item offset="43" id="15633" /> <!--Usukane Hizayoroi-->
-        <item offset="44" id="15719" /> <!--Usukane Sune-Ate-->
-        <item offset="45" id="16093" /> <!--H.kazu Hachimaki-->
-        <item offset="46" id="14555" /> <!--Hoshikazu Gi-->
-        <item offset="47" id="14970" /> <!--Hoshikazu Tekko-->
-        <item offset="48" id="15634" /> <!--Hoshikazu Hakama-->
-        <item offset="49" id="15720" /> <!--H.kazu Kyahan-->
-        <item offset="50" id="16094" /> <!--T.kazu Jinpachi-->
-        <item offset="51" id="14556" /> <!--Tsukikazu Togi-->
-        <item offset="52" id="14971" /> <!--Tsukikazu Gote-->
-        <item offset="53" id="15635" /> <!--Tsukikazu Haidate-->
-        <item offset="54" id="15721" /> <!--T.kazu Sune-Ate-->
-        <item offset="55" id="16095" /> <!--Hikazu Kabuto-->
-        <item offset="56" id="14557" /> <!--Hikazu Hara-Ate-->
-        <item offset="57" id="14972" /> <!--Hikazu Gote-->
-        <item offset="58" id="15636" /> <!--Hikazu Hakama-->
-        <item offset="59" id="15722" /> <!--Hikazu Sune-Ate-->
-        <item offset="60" id="16096" /> <!--Marduk's Tiara-->
-        <item offset="61" id="14558" /> <!--Marduk's Jubbah-->
-        <item offset="62" id="14973" /> <!--Marduk's Dastanas-->
-        <item offset="63" id="15637" /> <!--Marduk's Shalwar-->
-        <item offset="64" id="15723" /> <!--Marduk's Crackows-->
-        <item offset="65" id="16097" /> <!--Anu's Tiara-->
-        <item offset="66" id="14559" /> <!--Anu's Doublet-->
-        <item offset="67" id="14974" /> <!--Anu's Gages-->
-        <item offset="68" id="15638" /> <!--Anu's Brais-->
-        <item offset="69" id="15724" /> <!--Anu's Gaiters-->
-        <item offset="70" id="16098" /> <!--Ea's Tiara-->
-        <item offset="71" id="14560" /> <!--Ea's Doublet-->
-        <item offset="72" id="14975" /> <!--Ea's Dastanas-->
-        <item offset="73" id="15639" /> <!--Ea's Brais-->
-        <item offset="74" id="15725" /> <!--Ea's Crackows-->
-        <item offset="75" id="16099" /> <!--Enlil's Tiara-->
-        <item offset="76" id="14561" /> <!--Enlil's Gambison-->
-        <item offset="77" id="14976" /> <!--Enlil's Kolluks-->
-        <item offset="78" id="15640" /> <!--Enlil's Brayettes-->
-        <item offset="79" id="15726" /> <!--Enlil's Crackows-->
-        <item offset="80" id="16100" /> <!--Morrigan's Coron.-->
-        <item offset="81" id="14562" /> <!--Morrigan's Robe-->
-        <item offset="82" id="14977" /> <!--Morrigan's Cuffs-->
-        <item offset="83" id="15641" /> <!--Morrigan's Slops-->
-        <item offset="84" id="15727" /> <!--Morrigan's Pgch.-->
-        <item offset="85" id="16101" /> <!--Nemain's Crown-->
-        <item offset="86" id="14563" /> <!--Nemain's Robe-->
-        <item offset="87" id="14978" /> <!--Nemain's Cuffs-->
-        <item offset="88" id="15642" /> <!--Nemain's Slops-->
-        <item offset="89" id="15728" /> <!--Nemain's Sabots-->
-        <item offset="90" id="16102" /> <!--Bodb's Crown-->
-        <item offset="91" id="14564" /> <!--Bodb's Robe-->
-        <item offset="92" id="14979" /> <!--Bodb's Cuffs-->
-        <item offset="93" id="15643" /> <!--Bodb's Slops-->
-        <item offset="94" id="15729" /> <!--Bodb's Pigaches-->
-        <item offset="95" id="16103" /> <!--Macha's Crown-->
-        <item offset="96" id="14565" /> <!--Macha's Coat-->
-        <item offset="97" id="14980" /> <!--Macha's Cuffs-->
-        <item offset="98" id="15644" /> <!--Macha's Slops-->
-        <item offset="99" id="15730" /> <!--Macha's Pigaches-->
-        <item offset="100" id="16106" /> <!--Askar Zucchetto-->
-        <item offset="101" id="14568" /> <!--Askar Korazin-->
-        <item offset="102" id="14983" /> <!--Askar Manopolas-->
-        <item offset="103" id="15647" /> <!--Askar Dirs-->
-        <item offset="104" id="15733" /> <!--Askar Gambieras-->
-        <item offset="105" id="16107" /> <!--Denali Bonnet-->
-        <item offset="106" id="14569" /> <!--Denali Jacket-->
-        <item offset="107" id="14984" /> <!--Denali Wristbands-->
-        <item offset="108" id="15648" /> <!--Denali Kecks-->
-        <item offset="109" id="15734" /> <!--Denali Gamashes-->
-        <item offset="110" id="16108" /> <!--Goliard Chapeau-->
-        <item offset="111" id="14570" /> <!--Goliard Saio-->
-        <item offset="112" id="14985" /> <!--Goliard Cuffs-->
-        <item offset="113" id="15649" /> <!--Goliard Trews-->
-        <item offset="114" id="15735" /> <!--Goliard Clogs-->
-        <item offset="115" id="16602" /> <!--Perdu Sword-->
-        <item offset="116" id="17741" /> <!--Perdu Hanger-->
-        <item offset="117" id="18425" /> <!--Perdu Blade-->
-        <item offset="118" id="18491" /> <!--Perdu Voulge-->
-        <item offset="119" id="18588" /> <!--Perdu Staff-->
-        <item offset="120" id="18717" /> <!--Perdu Bow-->
-        <item offset="121" id="18718" /> <!--Perdu Crossbow-->
-        <item offset="122" id="18850" /> <!--Perdu Wand-->
-        <item offset="123" id="18943" /> <!--Perdu Sickle-->
-        <item offset="124" id="16069" /> <!--Pln. Qalansuwa-->
-        <item offset="125" id="14530" /> <!--Pln. Khazagand-->
-        <item offset="126" id="14940" /> <!--Pln. Dastanas-->
-        <item offset="127" id="15609" /> <!--Pln. Seraweels-->
-        <item offset="128" id="15695" /> <!--Pln. Crackows-->
-        <item offset="129" id="16062" /> <!--Amir Puggaree-->
-        <item offset="130" id="14525" /> <!--Amir Korazin-->
-        <item offset="131" id="14933" /> <!--Amir Kolluks-->
-        <item offset="132" id="15604" /> <!--Amir Dirs-->
-        <item offset="133" id="15688" /> <!--Amir Boots-->
-        <item offset="134" id="16064" /> <!--Yigit Turban-->
-        <item offset="135" id="14527" /> <!--Yigit Gomlek-->
-        <item offset="136" id="14935" /> <!--Yigit Gages-->
-        <item offset="137" id="15606" /> <!--Yigit Seraweels-->
-        <item offset="138" id="15690" /> <!--Yigit Crackows-->
-        <item offset="139" id="18685" /> <!--Imperial Kaman-->
-        <item offset="140" id="18065" /> <!--Storm Zaghnal-->
-        <item offset="141" id="17851" /> <!--Storm Fife-->
-        <item offset="142" id="18686" /> <!--Imperial Gun-->
-        <item offset="143" id="18025" /> <!--Khanjar-->
-        <item offset="144" id="18435" /> <!--Hotarumaru-->
-        <item offset="145" id="18113" /> <!--Imperial Neza-->
-        <item offset="146" id="17951" /> <!--Storm Tabar-->
-        <item offset="147" id="17715" /> <!--Storm Tulwar-->
-        <item offset="148" id="18485" /> <!--Imperial Bhuj-->
-        <item offset="149" id="18408" /> <!--Yigit Bulawa-->
-        <item offset="150" id="18365" /> <!--Pahluwan Patas-->
-        <item offset="151" id="18583" /> <!--Imperial Pole-->
-        <item offset="152" id="18417" /> <!--Sayosamonji-->
-        <item offset="153" id="18388" /> <!--Doombringer-->
-        <item offset="154" id="16267" /> <!--Ritter Gorget-->
-        <item offset="155" id="16268" /> <!--Kubira Beads-->
-        <item offset="156" id="16269" /> <!--Morgana's Choker-->
-        <item offset="157" id="16228" /> <!--Aslan Cape-->
-        <item offset="158" id="16229" /> <!--Gleeman's Cape-->
-        <item offset="159" id="15911" /> <!--Buccaneer's Belt-->
-        <item offset="160" id="15799" /> <!--Iota Ring-->
-        <item offset="161" id="15800" /> <!--Omega Ring-->
-        <item offset="162" id="15990" /> <!--Delta Earring-->
-        <item offset="163" id="17745" /> <!--Hofud-->
-        <item offset="164" id="18121" /> <!--Valkyrie's Fork-->
-        <item offset="165" id="16117" /> <!--Valhalla Helm-->
-        <item offset="166" id="14577" /> <!--Valhalla Brstplate-->
-        <item offset="167" id="17857" /> <!--Animator +1-->
-    </slip>
-    <slip id="29313">
-        <item offset="0" id="12421" /> <!--Koenig Schaller-->
-        <item offset="1" id="12549" /> <!--Koenig Cuirass-->
-        <item offset="2" id="12677" /> <!--Kng. Handschuhs-->
-        <item offset="3" id="12805" /> <!--Koenig Diechlings-->
-        <item offset="4" id="12933" /> <!--Koenig Schuhs-->
-        <item offset="5" id="13911" /> <!--Kaiser Schaller-->
-        <item offset="6" id="14370" /> <!--Kaiser Cuirass-->
-        <item offset="7" id="14061" /> <!--Kaiser Handschuhs-->
-        <item offset="8" id="14283" /> <!--Kaiser Diechlings-->
-        <item offset="9" id="14163" /> <!--Kaiser Schuhs-->
-        <item offset="10" id="12429" /> <!--Adaman Celata-->
-        <item offset="11" id="12557" /> <!--Adaman Hauberk-->
-        <item offset="12" id="12685" /> <!--Adaman Mufflers-->
-        <item offset="13" id="12813" /> <!--Adaman Breeches-->
-        <item offset="14" id="12941" /> <!--Adaman Sollerets-->
-        <item offset="15" id="13924" /> <!--Armada Celata-->
-        <item offset="16" id="14371" /> <!--Armada Hauberk-->
-        <item offset="17" id="14816" /> <!--Armada Mufflers-->
-        <item offset="18" id="14296" /> <!--Armada Breeches-->
-        <item offset="19" id="14175" /> <!--Armada Sollerets-->
-        <item offset="20" id="13934" /> <!--Shr.Znr.Kabuto-->
-        <item offset="21" id="14387" /> <!--Shura Togi-->
-        <item offset="22" id="14821" /> <!--Shura Kote-->
-        <item offset="23" id="14303" /> <!--Shura Haidate-->
-        <item offset="24" id="14184" /> <!--Shura Sune-Ate-->
-        <item offset="25" id="13935" /> <!--Shr.Znr.Kabuto +1-->
-        <item offset="26" id="14388" /> <!--Shura Togi +1-->
-        <item offset="27" id="14822" /> <!--Shura Kote +1-->
-        <item offset="28" id="14304" /> <!--Shura Haidate +1-->
-        <item offset="29" id="14185" /> <!--Shr. Sune-Ate +1-->
-        <item offset="30" id="13876" /> <!--Zenith Crown-->
-        <item offset="31" id="13787" /> <!--Dalmatica-->
-        <item offset="32" id="14006" /> <!--Zenith Mitts-->
-        <item offset="33" id="14247" /> <!--Zenith Slacks-->
-        <item offset="34" id="14123" /> <!--Zenith Pumps-->
-        <item offset="35" id="13877" /> <!--Zenith Crown +1-->
-        <item offset="36" id="13788" /> <!--Dalmatica +1-->
-        <item offset="37" id="14007" /> <!--Zenith Mitts +1-->
-        <item offset="38" id="14248" /> <!--Zenith Slacks +1-->
-        <item offset="39" id="14124" /> <!--Zenith Pumps +1-->
-        <item offset="40" id="13908" /> <!--Crimson Mask-->
-        <item offset="41" id="14367" /> <!--Crm. Scale Mail-->
-        <item offset="42" id="14058" /> <!--Crimson Fng. Gnt.-->
-        <item offset="43" id="14280" /> <!--Crimson Cuisses-->
-        <item offset="44" id="14160" /> <!--Crimson Greaves-->
-        <item offset="45" id="13909" /> <!--Blood Mask-->
-        <item offset="46" id="14368" /> <!--Blood Scale Mail-->
-        <item offset="47" id="14059" /> <!--Blood Fng. Gnt.-->
-        <item offset="48" id="14281" /> <!--Blood Cuisses-->
-        <item offset="49" id="14161" /> <!--Blood Greaves-->
-        <item offset="50" id="16113" /> <!--Shadow Helm-->
-        <item offset="51" id="14573" /> <!--Shadow Brstplate-->
-        <item offset="52" id="14995" /> <!--Shadow Gauntlets-->
-        <item offset="53" id="15655" /> <!--Shadow Cuishes-->
-        <item offset="54" id="15740" /> <!--Shadow Sabatons-->
-        <item offset="55" id="16115" /> <!--Shadow Hat-->
-        <item offset="56" id="14575" /> <!--Shadow Coat-->
-        <item offset="57" id="14997" /> <!--Shadow Cuffs-->
-        <item offset="58" id="15657" /> <!--Shadow Trews-->
-        <item offset="59" id="15742" /> <!--Shadow Clogs-->
-        <item offset="60" id="16114" /> <!--Valkyrie's Helm-->
-        <item offset="61" id="14574" /> <!--Valk. Breastplate-->
-        <item offset="62" id="14996" /> <!--Valk. Gauntlets-->
-        <item offset="63" id="15656" /> <!--Valkyrie's Cuishes-->
-        <item offset="64" id="15741" /> <!--Valk. Sabatons-->
-        <item offset="65" id="16116" /> <!--Valkyrie's Hat-->
-        <item offset="66" id="14576" /> <!--Valkyrie's Coat-->
-        <item offset="67" id="14998" /> <!--Valkyrie's Cuffs-->
-        <item offset="68" id="15658" /> <!--Valkyrie's Trews-->
-        <item offset="69" id="15743" /> <!--Valkyrie's Clogs-->
-        <item offset="70" id="12818" /> <!--Byakko's Haidate-->
-        <item offset="71" id="18198" /> <!--Byakko's Axe-->
-        <item offset="72" id="12946" /> <!--Suzaku's Sune-Ate-->
-        <item offset="73" id="18043" /> <!--Suzaku's Scythe-->
-        <item offset="74" id="12690" /> <!--Seiryu's Kote-->
-        <item offset="75" id="17659" /> <!--Seiryu's Sword-->
-        <item offset="76" id="12296" /> <!--Genbu's Shield-->
-        <item offset="77" id="12434" /> <!--Genbu's Kabuto-->
-        <item offset="78" id="15471" /> <!--Merciful Cape-->
-        <item offset="79" id="15472" /> <!--Altruistic Cape-->
-        <item offset="80" id="15473" /> <!--Astute Cape-->
-        <item offset="81" id="15508" /> <!--Justice Torque-->
-        <item offset="82" id="15509" /> <!--Hope Torque-->
-        <item offset="83" id="15510" /> <!--Prudence Torque-->
-        <item offset="84" id="15511" /> <!--Fortitude Torque-->
-        <item offset="85" id="15512" /> <!--Faith Torque-->
-        <item offset="86" id="15513" /> <!--Temp. Torque-->
-        <item offset="87" id="15514" /> <!--Love Torque-->
-        <item offset="88" id="17710" /> <!--Justice Sword-->
-        <item offset="89" id="17595" /> <!--Hope Staff-->
-        <item offset="90" id="18397" /> <!--Prudence Rod-->
-        <item offset="91" id="18360" /> <!--Faith Baghnakhs-->
-        <item offset="92" id="18222" /> <!--Fortitude Axe-->
-        <item offset="93" id="17948" /> <!--Temperance Axe-->
-        <item offset="94" id="18100" /> <!--Love Halberd-->
-        <item offset="95" id="15475" /> <!--Charger Mantle-->
-        <item offset="96" id="15476" /> <!--Jaeger Mantle-->
-        <item offset="97" id="15477" /> <!--Boxer's Mantle-->
-        <item offset="98" id="15488" /> <!--Gunner's Mantle-->
-        <item offset="99" id="15961" /> <!--Musical Earring-->
-        <item offset="100" id="14815" /> <!--Stealth Earring-->
-        <item offset="101" id="14812" /> <!--Loquac. Earring-->
-        <item offset="102" id="14813" /> <!--Brutal Earring-->
-        <item offset="103" id="15244" /> <!--Flawless Ribbon-->
-        <item offset="104" id="15240" /> <!--Homam Zucchetto-->
-        <item offset="105" id="14488" /> <!--Homam Corazza-->
-        <item offset="106" id="14905" /> <!--Homam Manopolas-->
-        <item offset="107" id="15576" /> <!--Homam Cosciales-->
-        <item offset="108" id="15661" /> <!--Homam Gambieras-->
-        <item offset="109" id="15241" /> <!--Nashira Turban-->
-        <item offset="110" id="14489" /> <!--Nashira Manteel-->
-        <item offset="111" id="14906" /> <!--Nashira Gages-->
-        <item offset="112" id="15577" /> <!--Nashira Seraweels-->
-        <item offset="113" id="15662" /> <!--Nashira Crackows-->
-        <item offset="114" id="13927" /> <!--Hecatomb Cap-->
-        <item offset="115" id="14378" /> <!--Hecatomb Harness-->
-        <item offset="116" id="14076" /> <!--Hecatomb Mittens-->
-        <item offset="117" id="14308" /> <!--Hecatomb Subligar-->
-        <item offset="118" id="14180" /> <!--Hct. Leggings-->
-        <item offset="119" id="13928" /> <!--Hecatomb Cap +1-->
-        <item offset="120" id="14379" /> <!--Hct. Harness +1-->
-        <item offset="121" id="14077" /> <!--Hct. Mittens +1-->
-        <item offset="122" id="14309" /> <!--Hct. Subligar +1-->
-        <item offset="123" id="14181" /> <!--Hct. Leggings +1-->
-        <item offset="124" id="10438" /> <!--Enif Zucchetto-->
-        <item offset="125" id="10276" /> <!--Enif Corazza-->
-        <item offset="126" id="10320" /> <!--Enif Manopolas-->
-        <item offset="127" id="10326" /> <!--Enif Cosciales-->
-        <item offset="128" id="10367" /> <!--Enif Gambieras-->
-        <item offset="129" id="10439" /> <!--Adhara Turban-->
-        <item offset="130" id="10277" /> <!--Adhara Manteel-->
-        <item offset="131" id="10321" /> <!--Adhara Gages-->
-        <item offset="132" id="10327" /> <!--Adhara Seraweels-->
-        <item offset="133" id="10368" /> <!--Adhara Crackows-->
-        <item offset="134" id="10440" /> <!--Murzim Zucchetto-->
-        <item offset="135" id="10278" /> <!--Murzim Corazza-->
-        <item offset="136" id="10322" /> <!--Murzim Manopolas-->
-        <item offset="137" id="10328" /> <!--Murzim Cosciales-->
-        <item offset="138" id="10369" /> <!--Murzim Gambieras-->
-        <item offset="139" id="10441" /> <!--Shedir Turban-->
-        <item offset="140" id="10279" /> <!--Shedir Manteel-->
-        <item offset="141" id="10323" /> <!--Shedir Gages-->
-        <item offset="142" id="10329" /> <!--Shedir Seraweels-->
-        <item offset="143" id="10370" /> <!--Shedir Crackows-->
-        <item offset="144" id="25734" /> <!--Pieuje Unity Shirt-->
-        <item offset="145" id="25735" /> <!--Ayame Unity Shirt-->
-        <item offset="146" id="25736" /> <!--I. Shield Unity Shirt-->
-        <item offset="147" id="25737" /> <!--Apururu Unity Shirt-->
-        <item offset="148" id="25738" /> <!--Maat Unity Shirt-->
-        <item offset="149" id="25739" /> <!--Aldo Unity Shirt-->
-        <item offset="150" id="25740" /> <!--Jakoh Unity Shirt-->
-        <item offset="151" id="25741" /> <!--Naja Unity Shirt-->
-        <item offset="152" id="25742" /> <!--Flaviria Unity Shirt-->
-        <item offset="153" id="25743" /> <!--Yoran Unity Shirt-->
-        <item offset="154" id="25744" /> <!--Sylvie Unity Shirt-->
-    </slip>
-    <slip id="29314">
-        <item offset="0" id="16155" /> <!--Aurum Armet-->
-        <item offset="1" id="11282" /> <!--Aurum Cuirass-->
-        <item offset="2" id="15021" /> <!--Aurum Gauntlets-->
-        <item offset="3" id="16341" /> <!--Aurum Cuisses-->
-        <item offset="4" id="11376" /> <!--Aurum Sabatons-->
-        <item offset="5" id="16156" /> <!--Oracle's Cap-->
-        <item offset="6" id="11283" /> <!--Oracle's Robe-->
-        <item offset="7" id="15022" /> <!--Oracle's Gloves-->
-        <item offset="8" id="16342" /> <!--Oracle's Braconi-->
-        <item offset="9" id="11377" /> <!--Oracle's Pigaches-->
-        <item offset="10" id="16157" /> <!--Enkidu's Cap-->
-        <item offset="11" id="11284" /> <!--Enkidu's Harness-->
-        <item offset="12" id="15023" /> <!--Enkidu's Mittens-->
-        <item offset="13" id="16343" /> <!--Enkidu's Subligar-->
-        <item offset="14" id="11378" /> <!--Enkidu's Leggings-->
-        <item offset="15" id="16148" /> <!--Cobra Cap-->
-        <item offset="16" id="14590" /> <!--Cobra Harness-->
-        <item offset="17" id="15011" /> <!--Cobra Mittens-->
-        <item offset="18" id="16317" /> <!--Cobra Subligar-->
-        <item offset="19" id="15757" /> <!--Cobra Leggings-->
-        <item offset="20" id="16143" /> <!--Cobra Hat-->
-        <item offset="21" id="14591" /> <!--Cobra Robe-->
-        <item offset="22" id="15012" /> <!--Cobra Gloves-->
-        <item offset="23" id="16318" /> <!--Cobra Trews-->
-        <item offset="24" id="15758" /> <!--Cobra Crackows-->
-        <item offset="25" id="16146" /> <!--Iron Ram Sallet-->
-        <item offset="26" id="14588" /> <!--Iron Ram Hauberk-->
-        <item offset="27" id="15009" /> <!--I.R. Dastanas-->
-        <item offset="28" id="16315" /> <!--Iron Ram Hose-->
-        <item offset="29" id="15755" /> <!--Iron Ram Greaves-->
-        <item offset="30" id="16147" /> <!--Fourth Haube-->
-        <item offset="31" id="14589" /> <!--Fourth Brunne-->
-        <item offset="32" id="15010" /> <!--Fourth Hentzes-->
-        <item offset="33" id="16316" /> <!--Fourth Schoss-->
-        <item offset="34" id="15756" /> <!--Fourth Schuhs-->
-        <item offset="35" id="15966" /> <!--Silver Fox Earring-->
-        <item offset="36" id="15967" /> <!--Temple Earring-->
-        <item offset="37" id="19041" /> <!--Rose Strap-->
-        <item offset="38" id="17684" /> <!--Griffinclaw-->
-        <item offset="39" id="17685" /> <!--Lex Talionis-->
-        <item offset="40" id="11636" /> <!--R.K. Sigil Ring-->
-        <item offset="41" id="15844" /> <!--Patronus Ring-->
-        <item offset="42" id="15934" /> <!--Crimson Belt-->
-        <item offset="43" id="16258" /> <!--Arrestor Mantle-->
-        <item offset="44" id="18735" /> <!--Sonia's Plectrum-->
-        <item offset="45" id="18734" /> <!--Sturm's Report-->
-        <item offset="46" id="16291" /> <!--Shield Collar-->
-        <item offset="47" id="16292" /> <!--Bull Necklace-->
-        <item offset="48" id="19042" /> <!--Ariesian Grip-->
-        <item offset="49" id="15935" /> <!--Capricornian Rope-->
-        <item offset="50" id="16293" /> <!--Cougar Pendant-->
-        <item offset="51" id="16294" /> <!--Crocodile Collar-->
-        <item offset="52" id="15936" /> <!--Earthy Belt-->
-        <item offset="53" id="18618" /> <!--Samudra-->
-        <item offset="54" id="11588" /> <!--Mrc.Mjr. Charm-->
-        <item offset="55" id="11545" /> <!--Fourth Mantle-->
-        <item offset="56" id="16158" /> <!--Gnadbhod's Helm-->
-        <item offset="57" id="16159" /> <!--Zha'Go's Barbut-->
-        <item offset="58" id="16160" /> <!--Ree's Headgear-->
-        <item offset="59" id="16149" /> <!--Cobra Cloche-->
-        <item offset="60" id="14583" /> <!--Cobra Coat-->
-        <item offset="61" id="15007" /> <!--Cobra Cuffs-->
-        <item offset="62" id="16314" /> <!--Cobra Slops-->
-        <item offset="63" id="15751" /> <!--Cobra Pigaches-->
-        <item offset="64" id="16141" /> <!--Iron Ram Helm-->
-        <item offset="65" id="14581" /> <!--I.R. Chainmail-->
-        <item offset="66" id="15005" /> <!--Iron Ram Mufflers-->
-        <item offset="67" id="16312" /> <!--I.R. Breeches-->
-        <item offset="68" id="15749" /> <!--I.R. Sollerets-->
-        <item offset="69" id="16142" /> <!--Fourth Armet-->
-        <item offset="70" id="14582" /> <!--Fourth Cuirass-->
-        <item offset="71" id="15006" /> <!--Fourth Gauntlets-->
-        <item offset="72" id="16313" /> <!--Fourth Cuisses-->
-        <item offset="73" id="15750" /> <!--Fourth Sabatons-->
-        <item offset="74" id="10876" /> <!--Ogier's Helm-->
-        <item offset="75" id="10450" /> <!--Ogier's Surcoat-->
-        <item offset="76" id="10500" /> <!--Ogier's Gauntlets-->
-        <item offset="77" id="11969" /> <!--Ogier's Breeches-->
-        <item offset="78" id="10600" /> <!--Ogier's Leggings-->
-        <item offset="79" id="10877" /> <!--Athos's Chapeau-->
-        <item offset="80" id="10451" /> <!--Athos's Tabard-->
-        <item offset="81" id="10501" /> <!--Athos's Gloves-->
-        <item offset="82" id="11970" /> <!--Athos's Tights-->
-        <item offset="83" id="10601" /> <!--Athos's Boots-->
-        <item offset="84" id="10878" /> <!--Rubeus Bandeau-->
-        <item offset="85" id="10452" /> <!--Rubeus Jacket-->
-        <item offset="86" id="10502" /> <!--Rubeus Gloves-->
-        <item offset="87" id="11971" /> <!--Rubeus Spats-->
-        <item offset="88" id="10602" /> <!--Rubeus Boots-->
-        <item offset="89" id="19132" /> <!--Twilight Knife-->
-        <item offset="90" id="18551" /> <!--Twilight Scythe-->
-        <item offset="91" id="11798" /> <!--Twilight Helm-->
-        <item offset="92" id="11362" /> <!--Twilight Mail-->
-        <item offset="93" id="11363" /> <!--Twilight Cloak-->
-        <item offset="94" id="11625" /> <!--Twilight Torque-->
-        <item offset="95" id="15959" /> <!--Twilight Belt-->
-        <item offset="96" id="16259" /> <!--Twilight Cape-->
-        <item offset="97" id="22299" /> <!--Per. Lucky Egg-->
-        <item offset="98" id="26414" /> <!--Twinned Shield-->
-        <item offset="99" id="21623" /> <!--Twinned Blade-->
-        <item offset="100" id="26219" /> <!--Naji's Loop-->
-        <item offset="101" id="21886" /> <!--Iapetus-->
-        <item offset="102" id="23792" /> <!--Ziamet Khud-->
-        <item offset="103" id="23793" /> <!--Ziamet Peti-->
-        <item offset="104" id="23794" /> <!--Ziamet Bazubands-->
-        <item offset="105" id="23795" /> <!--Ziamet Salvars-->
-        <item offset="106" id="23796" /> <!--Ziamet Nails-->
-        <item offset="107" id="22032" /> <!--Thunder Hammer-->
-        <item offset="108" id="22043" /> <!--Apkallu Scepter-->
-        <item offset="109" id="21530" /> <!--Tokkosho-->
-        <item offset="110" id="22044" /> <!--Tengu War Fan-->
-        <item offset="111" id="26273" /> <!--Tengu Shawl-->
-        <item offset="112" id="25415" /> <!--Rep. Plat. Medal-->
-        <item offset="113" id="25416" /> <!--Sibyl Scarf-->
-        <item offset="114" id="25414" /> <!--Elite Royal Collar-->
-        <item offset="115" id="22050" /> <!--Chac-chacs-->
-        <item offset="116" id="22302" /> <!--Oshasha's Treatise-->
-        <item offset="117" id="26365" /> <!--Cornelia's Belt-->
-        <item offset="118" id="26366" /> <!--Plat. Mog. Belt-->
-        <item offset="119" id="23862" /> <!--Boudox's Masque-->
-        <item offset="120" id="23863" /> <!--Boudox's Suit-->
-        <item offset="121" id="23864" /> <!--Magh Bihu's Masque-->
-        <item offset="122" id="23865" /> <!--Magh Bihu's Suit-->
-        <item offset="123" id="21536" /> <!--Dazbog's Knuckles-->
-    </slip>
-    <slip id="29315">
-        <item offset="0" id="12511" /> <!--Fighter's Mask-->
-        <item offset="1" id="12638" /> <!--Fighter's Lorica-->
-        <item offset="2" id="13961" /> <!--Fighter's Mufflers-->
-        <item offset="3" id="14214" /> <!--Fighter's Cuisses-->
-        <item offset="4" id="14089" /> <!--Fighter's Calligae-->
-        <item offset="5" id="12512" /> <!--Temple Crown-->
-        <item offset="6" id="12639" /> <!--Temple Cyclas-->
-        <item offset="7" id="13962" /> <!--Temple Gloves-->
-        <item offset="8" id="14215" /> <!--Temple Hose-->
-        <item offset="9" id="14090" /> <!--Temple Gaiters-->
-        <item offset="10" id="13855" /> <!--Healer's Cap-->
-        <item offset="11" id="12640" /> <!--Healer's Bliaut-->
-        <item offset="12" id="13963" /> <!--Healer's Mitts-->
-        <item offset="13" id="14216" /> <!--Healer's Pantaln.-->
-        <item offset="14" id="14091" /> <!--Healer's Duckbills-->
-        <item offset="15" id="13856" /> <!--Wizard's Petasos-->
-        <item offset="16" id="12641" /> <!--Wizard's Coat-->
-        <item offset="17" id="13964" /> <!--Wizard's Gloves-->
-        <item offset="18" id="14217" /> <!--Wizard's Tonban-->
-        <item offset="19" id="14092" /> <!--Wizard's Sabots-->
-        <item offset="20" id="12513" /> <!--Warlock's Chapeau-->
-        <item offset="21" id="12642" /> <!--Warlock's Tabard-->
-        <item offset="22" id="13965" /> <!--Warlock's Gloves-->
-        <item offset="23" id="14218" /> <!--Warlock's Tights-->
-        <item offset="24" id="14093" /> <!--Warlock's Boots-->
-        <item offset="25" id="12514" /> <!--Rogue's Bonnet-->
-        <item offset="26" id="12643" /> <!--Rogue's Vest-->
-        <item offset="27" id="13966" /> <!--Rogue's Armlets-->
-        <item offset="28" id="14219" /> <!--Rogue's Culottes-->
-        <item offset="29" id="14094" /> <!--Rogue's Poulaines-->
-        <item offset="30" id="12515" /> <!--Gallant Coronet-->
-        <item offset="31" id="12644" /> <!--Gallant Surcoat-->
-        <item offset="32" id="13967" /> <!--Gallant Gauntlets-->
-        <item offset="33" id="14220" /> <!--Gallant Breeches-->
-        <item offset="34" id="14095" /> <!--Gallant Leggings-->
-        <item offset="35" id="12516" /> <!--Chaos Burgeonet-->
-        <item offset="36" id="12645" /> <!--Chaos Cuirass-->
-        <item offset="37" id="13968" /> <!--Chaos Gauntlets-->
-        <item offset="38" id="14221" /> <!--Chaos Flanchard-->
-        <item offset="39" id="14096" /> <!--Chaos Sollerets-->
-        <item offset="40" id="12517" /> <!--Beast Helm-->
-        <item offset="41" id="12646" /> <!--Beast Jackcoat-->
-        <item offset="42" id="13969" /> <!--Beast Gloves-->
-        <item offset="43" id="14222" /> <!--Beast Trousers-->
-        <item offset="44" id="14097" /> <!--Beast Gaiters-->
-        <item offset="45" id="13857" /> <!--Choral Roundlet-->
-        <item offset="46" id="12647" /> <!--Choral Jstcorps-->
-        <item offset="47" id="13970" /> <!--Choral Cuffs-->
-        <item offset="48" id="14223" /> <!--Choral Cannions-->
-        <item offset="49" id="14098" /> <!--Choral Slippers-->
-        <item offset="50" id="12518" /> <!--Hunter's Beret-->
-        <item offset="51" id="12648" /> <!--Hunter's Jerkin-->
-        <item offset="52" id="13971" /> <!--Hunter's Bracers-->
-        <item offset="53" id="14099" /> <!--Hunter's Socks-->
-        <item offset="54" id="14224" /> <!--Hunter's Braccae-->
-        <item offset="55" id="13868" /> <!--Myochin Kabuto-->
-        <item offset="56" id="13781" /> <!--Myochin Domaru-->
-        <item offset="57" id="13972" /> <!--Myochin Kote-->
-        <item offset="58" id="14225" /> <!--Myochin Haidate-->
-        <item offset="59" id="14100" /> <!--Myochin Sune-Ate-->
-        <item offset="60" id="13869" /> <!--Ninja Hatsuburi-->
-        <item offset="61" id="13782" /> <!--Ninja Chainmail-->
-        <item offset="62" id="13973" /> <!--Ninja Tekko-->
-        <item offset="63" id="14226" /> <!--Ninja Hakama-->
-        <item offset="64" id="14101" /> <!--Ninja Kyahan-->
-        <item offset="65" id="12519" /> <!--Drachen Armet-->
-        <item offset="66" id="12649" /> <!--Drachen Mail-->
-        <item offset="67" id="13974" /> <!--Drachen Fng. Gnt.-->
-        <item offset="68" id="14227" /> <!--Drachen Brais-->
-        <item offset="69" id="14102" /> <!--Drachen Greaves-->
-        <item offset="70" id="12520" /> <!--Evoker's Horn-->
-        <item offset="71" id="12650" /> <!--Evoker's Doublet-->
-        <item offset="72" id="13975" /> <!--Evoker's Bracers-->
-        <item offset="73" id="14228" /> <!--Evoker's Spats-->
-        <item offset="74" id="14103" /> <!--Evoker's Pigaches-->
-        <item offset="75" id="15265" /> <!--Magus Keffiyeh-->
-        <item offset="76" id="14521" /> <!--Magus Jubbah-->
-        <item offset="77" id="14928" /> <!--Magus Bazubands-->
-        <item offset="78" id="15600" /> <!--Magus Shalwar-->
-        <item offset="79" id="15684" /> <!--Magus Charuqs-->
-        <item offset="80" id="15266" /> <!--Corsair's Tricorne-->
-        <item offset="81" id="14522" /> <!--Corsair's Frac-->
-        <item offset="82" id="14929" /> <!--Corsair's Gants-->
-        <item offset="83" id="15601" /> <!--Corsair's Culottes-->
-        <item offset="84" id="15685" /> <!--Corsair's Bottes-->
-        <item offset="85" id="15267" /> <!--Pup. Taj-->
-        <item offset="86" id="14523" /> <!--Pup. Tobe-->
-        <item offset="87" id="14930" /> <!--Pup. Dastanas-->
-        <item offset="88" id="15602" /> <!--Pup. Churidars-->
-        <item offset="89" id="15686" /> <!--Pup. Babouches-->
-        <item offset="90" id="16138" /> <!--Dancer's Tiara-->
-        <item offset="91" id="14578" /> <!--Dancer's Casaque-->
-        <item offset="92" id="15002" /> <!--Dancer's Bangles-->
-        <item offset="93" id="15659" /> <!--Dancer's Tights-->
-        <item offset="94" id="15746" /> <!--Dancer's Toe Shoes-->
-        <item offset="95" id="16139" /> <!--Dancer's Tiara-->
-        <item offset="96" id="14579" /> <!--Dancer's Casaque-->
-        <item offset="97" id="15003" /> <!--Dancer's Bangles-->
-        <item offset="98" id="15660" /> <!--Dancer's Tights-->
-        <item offset="99" id="15747" /> <!--Dancer's Toe Shoes-->
-        <item offset="100" id="16140" /> <!--Scholar's M.board-->
-        <item offset="101" id="14580" /> <!--Scholar's Gown-->
-        <item offset="102" id="15004" /> <!--Scholar's Bracers-->
-        <item offset="103" id="16311" /> <!--Scholar's Pants-->
-        <item offset="104" id="15748" /> <!--Scholar's Loafers-->
-        <item offset="105" id="16678" /> <!--Razor Axe-->
-        <item offset="106" id="17478" /> <!--Beat Cesti-->
-        <item offset="107" id="17422" /> <!--Blessed Hammer-->
-        <item offset="108" id="17423" /> <!--Casting Wand-->
-        <item offset="109" id="16829" /> <!--Fencing Degen-->
-        <item offset="110" id="16764" /> <!--Marauder's Knife-->
-        <item offset="111" id="17643" /> <!--Honor Sword-->
-        <item offset="112" id="16798" /> <!--Raven Scythe-->
-        <item offset="113" id="16680" /> <!--Barbaroi Axe-->
-        <item offset="114" id="16766" /> <!--Paper Knife-->
-        <item offset="115" id="17188" /> <!--Sniping Bow-->
-        <item offset="116" id="17812" /> <!--Magoroku-->
-        <item offset="117" id="17771" /> <!--Anju-->
-        <item offset="118" id="17772" /> <!--Zushio-->
-        <item offset="119" id="16887" /> <!--Peregrine-->
-        <item offset="120" id="17532" /> <!--Kukulcan's Staff-->
-        <item offset="121" id="17717" /> <!--Immortal's Scimitar-->
-        <item offset="122" id="18702" /> <!--Trump Gun-->
-        <item offset="123" id="17858" /> <!--Turbo Animator-->
-        <item offset="124" id="19203" /> <!--War Hoop-->
-        <item offset="125" id="21461" /> <!--Filiae Bell-->
-        <item offset="126" id="21124" /> <!--Dowser's Wand-->
-        <item offset="127" id="20776" /> <!--Beorc Sword-->
-        <item offset="128" id="27786" /> <!--Geomancy Galero-->
-        <item offset="129" id="27926" /> <!--Geomancy Tunic-->
-        <item offset="130" id="28066" /> <!--Geomancy Mitaines-->
-        <item offset="131" id="28206" /> <!--Geomancy Pants-->
-        <item offset="132" id="28346" /> <!--Geomancy Sandals-->
-        <item offset="133" id="27787" /> <!--Runeist Bandeau-->
-        <item offset="134" id="27927" /> <!--Runeist Coat-->
-        <item offset="135" id="28067" /> <!--Runeist Mitons-->
-        <item offset="136" id="28207" /> <!--Runeist Trousers-->
-        <item offset="137" id="28347" /> <!--Runeist Bottes-->
-    </slip>
-    <slip id="29316">
-        <item offset="0" id="15225" /> <!--Ftr. Mask +1-->
-        <item offset="1" id="14473" /> <!--Ftr. Lorica +1-->
-        <item offset="2" id="14890" /> <!--Ftr. Mufflers +1-->
-        <item offset="3" id="15561" /> <!--Ftr. Cuisses +1-->
-        <item offset="4" id="15352" /> <!--Ftr. Calligae +1-->
-        <item offset="5" id="15226" /> <!--Tpl. Crown +1-->
-        <item offset="6" id="14474" /> <!--Tpl. Cyclas +1-->
-        <item offset="7" id="14891" /> <!--Tpl. Gloves +1-->
-        <item offset="8" id="15562" /> <!--Tpl. Hose +1-->
-        <item offset="9" id="15353" /> <!--Tpl. Gaiters +1-->
-        <item offset="10" id="15227" /> <!--Hlr. Cap +1-->
-        <item offset="11" id="14475" /> <!--Hlr. Bliaut +1-->
-        <item offset="12" id="14892" /> <!--Hlr. Mitts +1-->
-        <item offset="13" id="15563" /> <!--Hlr. Pantaln. +1-->
-        <item offset="14" id="15354" /> <!--Hlr. Duckbills +1-->
-        <item offset="15" id="15228" /> <!--Wzd. Petasos +1-->
-        <item offset="16" id="14476" /> <!--Wzd. Coat +1-->
-        <item offset="17" id="14893" /> <!--Wzd. Gloves +1-->
-        <item offset="18" id="15564" /> <!--Wzd. Tonban +1-->
-        <item offset="19" id="15355" /> <!--Wzd. Sabots +1-->
-        <item offset="20" id="15229" /> <!--Wlk. Chapeau +1-->
-        <item offset="21" id="14477" /> <!--Wlk. Tabard +1-->
-        <item offset="22" id="14894" /> <!--Wlk. Gloves +1-->
-        <item offset="23" id="15565" /> <!--Wlk. Tights +1-->
-        <item offset="24" id="15356" /> <!--Wlk. Boots +1-->
-        <item offset="25" id="15230" /> <!--Rog. Bonnet +1-->
-        <item offset="26" id="14478" /> <!--Rog. Vest +1-->
-        <item offset="27" id="14895" /> <!--Rog. Armlets +1-->
-        <item offset="28" id="15566" /> <!--Rog. Culottes +1-->
-        <item offset="29" id="15357" /> <!--Rog. Poulaines +1-->
-        <item offset="30" id="15231" /> <!--Glt. Coronet +1-->
-        <item offset="31" id="14479" /> <!--Glt. Surcoat +1-->
-        <item offset="32" id="14896" /> <!--Glt. Gauntlets +1-->
-        <item offset="33" id="15567" /> <!--Glt. Breeches +1-->
-        <item offset="34" id="15358" /> <!--Glt. Leggings +1-->
-        <item offset="35" id="15232" /> <!--Chs. Burgeonet +1-->
-        <item offset="36" id="14480" /> <!--Chs. Cuirass +1-->
-        <item offset="37" id="14897" /> <!--Chs. Gauntlets +1-->
-        <item offset="38" id="15568" /> <!--Chs. Flanchard +1-->
-        <item offset="39" id="15359" /> <!--Chs. Sollerets +1-->
-        <item offset="40" id="15233" /> <!--Bst. Helm +1-->
-        <item offset="41" id="14481" /> <!--Bst. Jackcoat +1-->
-        <item offset="42" id="14898" /> <!--Bst. Gloves +1-->
-        <item offset="43" id="15569" /> <!--Bst. Trousers +1-->
-        <item offset="44" id="15360" /> <!--Bst. Gaiters +1-->
-        <item offset="45" id="15234" /> <!--Chl. Roundlet +1-->
-        <item offset="46" id="14482" /> <!--Chl. Jstcorps +1-->
-        <item offset="47" id="14899" /> <!--Chl. Cuffs +1-->
-        <item offset="48" id="15570" /> <!--Chl. Cannions +1-->
-        <item offset="49" id="15361" /> <!--Chl. Slippers +1-->
-        <item offset="50" id="15235" /> <!--Htr. Beret +1-->
-        <item offset="51" id="14483" /> <!--Htr. Jerkin +1-->
-        <item offset="52" id="14900" /> <!--Htr. Bracers +1-->
-        <item offset="53" id="15362" /> <!--Htr. Socks +1-->
-        <item offset="54" id="15571" /> <!--Htr. Braccae +1-->
-        <item offset="55" id="15236" /> <!--Myn. Kabuto +1-->
-        <item offset="56" id="14484" /> <!--Myn. Domaru +1-->
-        <item offset="57" id="14901" /> <!--Myn. Kote +1-->
-        <item offset="58" id="15572" /> <!--Myn. Haidate +1-->
-        <item offset="59" id="15363" /> <!--Myn. Sune-Ate +1-->
-        <item offset="60" id="15237" /> <!--Nin. Hatsuburi +1-->
-        <item offset="61" id="14485" /> <!--Nin. Chainmail +1-->
-        <item offset="62" id="14902" /> <!--Nin. Tekko +1-->
-        <item offset="63" id="15573" /> <!--Nin. Hakama +1-->
-        <item offset="64" id="15364" /> <!--Nin. Kyahan +1-->
-        <item offset="65" id="15238" /> <!--Drn. Armet +1-->
-        <item offset="66" id="14486" /> <!--Drn. Mail +1-->
-        <item offset="67" id="14903" /> <!--Drn. Fng. Gnt. +1-->
-        <item offset="68" id="15574" /> <!--Drn. Brais +1-->
-        <item offset="69" id="15365" /> <!--Drn. Greaves +1-->
-        <item offset="70" id="15239" /> <!--Evk. Horn +1-->
-        <item offset="71" id="14487" /> <!--Evk. Doublet +1-->
-        <item offset="72" id="14904" /> <!--Evk. Bracers +1-->
-        <item offset="73" id="15575" /> <!--Evk. Spats +1-->
-        <item offset="74" id="15366" /> <!--Evk. Pigaches +1-->
-        <item offset="75" id="11464" /> <!--Magus Keffiyeh +1-->
-        <item offset="76" id="11291" /> <!--Magus Jubbah +1-->
-        <item offset="77" id="15024" /> <!--Mag. Bazubands +1-->
-        <item offset="78" id="16345" /> <!--Magus Shalwar +1-->
-        <item offset="79" id="11381" /> <!--Magus Charuqs +1-->
-        <item offset="80" id="11467" /> <!--Cor. Tricorne +1-->
-        <item offset="81" id="11294" /> <!--Corsair's Frac +1-->
-        <item offset="82" id="15027" /> <!--Corsair's Gants +1-->
-        <item offset="83" id="16348" /> <!--Cor. Culottes +1-->
-        <item offset="84" id="11384" /> <!--Cor. Bottes +1-->
-        <item offset="85" id="11470" /> <!--Puppetry Taj +1-->
-        <item offset="86" id="11297" /> <!--Pup. Tobe +1-->
-        <item offset="87" id="15030" /> <!--Pup. Dastanas +1-->
-        <item offset="88" id="16351" /> <!--Pup. Churidars +1-->
-        <item offset="89" id="11387" /> <!--Pup. Babouches +1-->
-        <item offset="90" id="11475" /> <!--Dancer's Tiara +1-->
-        <item offset="91" id="11302" /> <!--Dnc. Casaque +1-->
-        <item offset="92" id="15035" /> <!--Dnc. Bangles +1-->
-        <item offset="93" id="16357" /> <!--Dancer's Tights +1-->
-        <item offset="94" id="11393" /> <!--Dancer's Toe Shoes +1-->
-        <item offset="95" id="11476" /> <!--Dancer's Tiara +1-->
-        <item offset="96" id="11303" /> <!--Dnc. Casaque +1-->
-        <item offset="97" id="15036" /> <!--Dnc. Bangles +1-->
-        <item offset="98" id="16358" /> <!--Dancer's Tights +1-->
-        <item offset="99" id="11394" /> <!--Dancer's Toe Shoes +1-->
-        <item offset="100" id="11477" /> <!--Sch. M.board +1-->
-        <item offset="101" id="11304" /> <!--Scholar's Gown +1-->
-        <item offset="102" id="15037" /> <!--Sch. Bracers +1-->
-        <item offset="103" id="16359" /> <!--Scholar's Pants +1-->
-        <item offset="104" id="11395" /> <!--Sch. Loafers +1-->
-    </slip>
-    <slip id="29317">
-        <item offset="0" id="15072" /> <!--Warrior's Mask-->
-        <item offset="1" id="15087" /> <!--Warrior's Lorica-->
-        <item offset="2" id="15102" /> <!--Warrior's Mufflers-->
-        <item offset="3" id="15117" /> <!--Warrior's Cuisses-->
-        <item offset="4" id="15132" /> <!--Warrior's Calligae-->
-        <item offset="5" id="15871" /> <!--Warrior's Stone-->
-        <item offset="6" id="15073" /> <!--Melee Crown-->
-        <item offset="7" id="15088" /> <!--Melee Cyclas-->
-        <item offset="8" id="15103" /> <!--Melee Gloves-->
-        <item offset="9" id="15118" /> <!--Melee Hose-->
-        <item offset="10" id="15133" /> <!--Melee Gaiters-->
-        <item offset="11" id="15478" /> <!--Melee Cape-->
-        <item offset="12" id="15074" /> <!--Cleric's Cap-->
-        <item offset="13" id="15089" /> <!--Cleric's Bliaut-->
-        <item offset="14" id="15104" /> <!--Cleric's Mitts-->
-        <item offset="15" id="15119" /> <!--Cleric's Pantaln.-->
-        <item offset="16" id="15134" /> <!--Cleric's Duckbills-->
-        <item offset="17" id="15872" /> <!--Cleric's Belt-->
-        <item offset="18" id="15075" /> <!--Sorcerer's Petas.-->
-        <item offset="19" id="15090" /> <!--Sorcerer's Coat-->
-        <item offset="20" id="15105" /> <!--Sorcerer's Gloves-->
-        <item offset="21" id="15120" /> <!--Sorcerer's Tonban-->
-        <item offset="22" id="15135" /> <!--Sorcerer's Sabots-->
-        <item offset="23" id="15874" /> <!--Sorcerer's Belt-->
-        <item offset="24" id="15076" /> <!--Duelist's Chapeau-->
-        <item offset="25" id="15091" /> <!--Duelist's Tabard-->
-        <item offset="26" id="15106" /> <!--Duelist's Gloves-->
-        <item offset="27" id="15121" /> <!--Duelist's Tights-->
-        <item offset="28" id="15136" /> <!--Duelist's Boots-->
-        <item offset="29" id="15873" /> <!--Duelist's Belt-->
-        <item offset="30" id="15077" /> <!--Assassin's Bonnet-->
-        <item offset="31" id="15092" /> <!--Assassin's Vest-->
-        <item offset="32" id="15107" /> <!--Assassin's Armlets-->
-        <item offset="33" id="15122" /> <!--Assassin's Culottes-->
-        <item offset="34" id="15137" /> <!--Assassin's Pouln.-->
-        <item offset="35" id="15480" /> <!--Assassin's Cape-->
-        <item offset="36" id="15078" /> <!--Valor Coronet-->
-        <item offset="37" id="15093" /> <!--Valor Surcoat-->
-        <item offset="38" id="15108" /> <!--Valor Gauntlets-->
-        <item offset="39" id="15123" /> <!--Valor Breeches-->
-        <item offset="40" id="15138" /> <!--Valor Leggings-->
-        <item offset="41" id="15481" /> <!--Valor Cape-->
-        <item offset="42" id="15079" /> <!--Abyss Burgeonet-->
-        <item offset="43" id="15094" /> <!--Abyss Cuirass-->
-        <item offset="44" id="15109" /> <!--Abyss Gauntlets-->
-        <item offset="45" id="15124" /> <!--Abyss Flanchard-->
-        <item offset="46" id="15139" /> <!--Abyss Sollerets-->
-        <item offset="47" id="15479" /> <!--Abyss Cape-->
-        <item offset="48" id="15080" /> <!--Monster Helm-->
-        <item offset="49" id="15095" /> <!--Monster Jackcoat-->
-        <item offset="50" id="15110" /> <!--Monster Gloves-->
-        <item offset="51" id="15125" /> <!--Monster Trousers-->
-        <item offset="52" id="15140" /> <!--Monster Gaiters-->
-        <item offset="53" id="15875" /> <!--Monster Belt-->
-        <item offset="54" id="15081" /> <!--Bard's Roundlet-->
-        <item offset="55" id="15096" /> <!--Bard's Jstcorps-->
-        <item offset="56" id="15111" /> <!--Bard's Cuffs-->
-        <item offset="57" id="15126" /> <!--Bard's Cannions-->
-        <item offset="58" id="15141" /> <!--Bard's Slippers-->
-        <item offset="59" id="15482" /> <!--Bard's Cape-->
-        <item offset="60" id="15082" /> <!--Scout's Beret-->
-        <item offset="61" id="15097" /> <!--Scout's Jerkin-->
-        <item offset="62" id="15112" /> <!--Scout's Bracers-->
-        <item offset="63" id="15127" /> <!--Scout's Braccae-->
-        <item offset="64" id="15142" /> <!--Scout's Socks-->
-        <item offset="65" id="15876" /> <!--Scout's Belt-->
-        <item offset="66" id="15083" /> <!--Saotome Kabuto-->
-        <item offset="67" id="15098" /> <!--Saotome Domaru-->
-        <item offset="68" id="15113" /> <!--Saotome Kote-->
-        <item offset="69" id="15128" /> <!--Saotome Haidate-->
-        <item offset="70" id="15143" /> <!--Saotome Sune-Ate-->
-        <item offset="71" id="15879" /> <!--Sao. Koshi-Ate-->
-        <item offset="72" id="15084" /> <!--Koga Hatsuburi-->
-        <item offset="73" id="15099" /> <!--Koga Chainmail-->
-        <item offset="74" id="15114" /> <!--Koga Tekko-->
-        <item offset="75" id="15129" /> <!--Koga Hakama-->
-        <item offset="76" id="15144" /> <!--Koga Kyahan-->
-        <item offset="77" id="15877" /> <!--Koga Sarashi-->
-        <item offset="78" id="15085" /> <!--Wyrm Armet-->
-        <item offset="79" id="15100" /> <!--Wyrm Mail-->
-        <item offset="80" id="15115" /> <!--Wyrm Fng.Gnt.-->
-        <item offset="81" id="15130" /> <!--Wyrm Brais-->
-        <item offset="82" id="15145" /> <!--Wyrm Greaves-->
-        <item offset="83" id="15878" /> <!--Wyrm Belt-->
-        <item offset="84" id="15086" /> <!--Summoner's Horn-->
-        <item offset="85" id="15101" /> <!--Summoner's Dblt.-->
-        <item offset="86" id="15116" /> <!--Summoner's Brcr.-->
-        <item offset="87" id="15131" /> <!--Summoner's Spats-->
-        <item offset="88" id="15146" /> <!--Summoner's Pgch.-->
-        <item offset="89" id="15484" /> <!--Summoner's Cape-->
-        <item offset="90" id="11465" /> <!--Mirage Keffiyeh-->
-        <item offset="91" id="11292" /> <!--Mirage Jubbah-->
-        <item offset="92" id="15025" /> <!--Mirage Bazubands-->
-        <item offset="93" id="16346" /> <!--Mirage Shalwar-->
-        <item offset="94" id="11382" /> <!--Mirage Charuqs-->
-        <item offset="95" id="16244" /> <!--Mirage Mantle-->
-        <item offset="96" id="11468" /> <!--Comm. Tricorne-->
-        <item offset="97" id="11295" /> <!--Commodore Frac-->
-        <item offset="98" id="15028" /> <!--Commodore Gants-->
-        <item offset="99" id="16349" /> <!--Comm. Trews-->
-        <item offset="100" id="11385" /> <!--Comm. Bottes-->
-        <item offset="101" id="15920" /> <!--Commodore Belt-->
-        <item offset="102" id="11471" /> <!--Pantin Taj-->
-        <item offset="103" id="11298" /> <!--Pantin Tobe-->
-        <item offset="104" id="15031" /> <!--Pantin Dastanas-->
-        <item offset="105" id="16352" /> <!--Pantin Churidars-->
-        <item offset="106" id="11388" /> <!--Pantin Babouches-->
-        <item offset="107" id="16245" /> <!--Pantin Cape-->
-        <item offset="108" id="11478" /> <!--Etoile Tiara-->
-        <item offset="109" id="11305" /> <!--Etoile Casaque-->
-        <item offset="110" id="15038" /> <!--Etoile Bangles-->
-        <item offset="111" id="16360" /> <!--Etoile Tights-->
-        <item offset="112" id="11396" /> <!--Etoile Toe Shoes-->
-        <item offset="113" id="16248" /> <!--Etoile Cape-->
-        <item offset="114" id="11480" /> <!--Argute M.board-->
-        <item offset="115" id="11307" /> <!--Argute Gown-->
-        <item offset="116" id="15040" /> <!--Argute Bracers-->
-        <item offset="117" id="16362" /> <!--Argute Pants-->
-        <item offset="118" id="11398" /> <!--Argute Loafers-->
-        <item offset="119" id="15925" /> <!--Argute Belt-->
-    </slip>
-    <slip id="29318">
-        <item offset="0" id="15245" /> <!--War. Mask +1-->
-        <item offset="1" id="14500" /> <!--War. Lorica +1-->
-        <item offset="2" id="14909" /> <!--War. Mufflers +1-->
-        <item offset="3" id="15580" /> <!--War. Cuisses +1-->
-        <item offset="4" id="15665" /> <!--War. Calligae +1-->
-        <item offset="5" id="15246" /> <!--Mel. Crown +1-->
-        <item offset="6" id="14501" /> <!--Mel. Cyclas +1-->
-        <item offset="7" id="14910" /> <!--Mel. Gloves +1-->
-        <item offset="8" id="15581" /> <!--Mel. Hose +1-->
-        <item offset="9" id="15666" /> <!--Mel. Gaiters +1-->
-        <item offset="10" id="15247" /> <!--Clr. Cap +1-->
-        <item offset="11" id="14502" /> <!--Clr. Bliaut +1-->
-        <item offset="12" id="14911" /> <!--Clr. Mitts +1-->
-        <item offset="13" id="15582" /> <!--Clr. Pantaln. +1-->
-        <item offset="14" id="15667" /> <!--Clr. Duckbills +1-->
-        <item offset="15" id="15248" /> <!--Src. Petasos +1-->
-        <item offset="16" id="14503" /> <!--Src. Coat +1-->
-        <item offset="17" id="14912" /> <!--Src. Gloves +1-->
-        <item offset="18" id="15583" /> <!--Src. Tonban +1-->
-        <item offset="19" id="15668" /> <!--Src. Sabots +1-->
-        <item offset="20" id="15249" /> <!--Dls. Chapeau +1-->
-        <item offset="21" id="14504" /> <!--Dls. Tabard +1-->
-        <item offset="22" id="14913" /> <!--Dls. Gloves +1-->
-        <item offset="23" id="15584" /> <!--Dls. Tights +1-->
-        <item offset="24" id="15669" /> <!--Dls. Boots +1-->
-        <item offset="25" id="15250" /> <!--Asn. Bonnet +1-->
-        <item offset="26" id="14505" /> <!--Asn. Vest +1-->
-        <item offset="27" id="14914" /> <!--Asn. Armlets +1-->
-        <item offset="28" id="15585" /> <!--Asn. Culottes +1-->
-        <item offset="29" id="15670" /> <!--Asn. Poulaines +1-->
-        <item offset="30" id="15251" /> <!--Vlr. Coronet +1-->
-        <item offset="31" id="14506" /> <!--Vlr. Surcoat +1-->
-        <item offset="32" id="14915" /> <!--Vlr. Gauntlets +1-->
-        <item offset="33" id="15586" /> <!--Vlr. Breeches +1-->
-        <item offset="34" id="15671" /> <!--Vlr. Leggings +1-->
-        <item offset="35" id="15252" /> <!--Abs. Burgeonet +1-->
-        <item offset="36" id="14507" /> <!--Abs. Cuirass +1-->
-        <item offset="37" id="14916" /> <!--Abs. Gauntlets +1-->
-        <item offset="38" id="15587" /> <!--Abs. Flanchard +1-->
-        <item offset="39" id="15672" /> <!--Abs. Sollerets +1-->
-        <item offset="40" id="15253" /> <!--Mst. Helm +1-->
-        <item offset="41" id="14508" /> <!--Mst. Jackcoat +1-->
-        <item offset="42" id="14917" /> <!--Mst. Gloves +1-->
-        <item offset="43" id="15588" /> <!--Mst. Trousers +1-->
-        <item offset="44" id="15673" /> <!--Mst. Gaiters +1-->
-        <item offset="45" id="15254" /> <!--Brd. Roundlet +1-->
-        <item offset="46" id="14509" /> <!--Brd. Jstcorps +1-->
-        <item offset="47" id="14918" /> <!--Brd. Cuffs +1-->
-        <item offset="48" id="15589" /> <!--Brd. Cannions +1-->
-        <item offset="49" id="15674" /> <!--Brd. Slippers +1-->
-        <item offset="50" id="15255" /> <!--Sct. Beret +1-->
-        <item offset="51" id="14510" /> <!--Sct. Jerkin +1-->
-        <item offset="52" id="14919" /> <!--Sct. Bracers +1-->
-        <item offset="53" id="15590" /> <!--Sct. Braccae +1-->
-        <item offset="54" id="15675" /> <!--Sct. Socks +1-->
-        <item offset="55" id="15256" /> <!--Sao. Kabuto +1-->
-        <item offset="56" id="14511" /> <!--Sao. Domaru +1-->
-        <item offset="57" id="14920" /> <!--Sao. Kote +1-->
-        <item offset="58" id="15591" /> <!--Sao. Haidate +1-->
-        <item offset="59" id="15676" /> <!--Sao. Sune-Ate +1-->
-        <item offset="60" id="15257" /> <!--Kog. Hatsuburi +1-->
-        <item offset="61" id="14512" /> <!--Kog. Chainmail +1-->
-        <item offset="62" id="14921" /> <!--Kog. Tekko +1-->
-        <item offset="63" id="15592" /> <!--Kog. Hakama +1-->
-        <item offset="64" id="15677" /> <!--Kog. Kyahan +1-->
-        <item offset="65" id="15258" /> <!--Wym. Armet +1-->
-        <item offset="66" id="14513" /> <!--Wym. Mail +1-->
-        <item offset="67" id="14922" /> <!--Wym. Fng. Gnt. +1-->
-        <item offset="68" id="15593" /> <!--Wym. Brais +1-->
-        <item offset="69" id="15678" /> <!--Wym. Greaves +1-->
-        <item offset="70" id="15259" /> <!--Smn. Horn +1-->
-        <item offset="71" id="14514" /> <!--Smn. Doublet +1-->
-        <item offset="72" id="14923" /> <!--Smn. Bracers +1-->
-        <item offset="73" id="15594" /> <!--Smn. Spats +1-->
-        <item offset="74" id="15679" /> <!--Smn. Pigaches +1-->
-        <item offset="75" id="11466" /> <!--Mirage Keffiyeh +1-->
-        <item offset="76" id="11293" /> <!--Mirage Jubbah +1-->
-        <item offset="77" id="15026" /> <!--Mrg. Bazubands +1-->
-        <item offset="78" id="16347" /> <!--Mirage Shalwar +1-->
-        <item offset="79" id="11383" /> <!--Mirage Charuqs +1-->
-        <item offset="80" id="11469" /> <!--Comm. Tricorne +1-->
-        <item offset="81" id="11296" /> <!--Comm. Frac +1-->
-        <item offset="82" id="15029" /> <!--Comm. Gants +1-->
-        <item offset="83" id="16350" /> <!--Comm. Trews +1-->
-        <item offset="84" id="11386" /> <!--Comm. Bottes +1-->
-        <item offset="85" id="11472" /> <!--Pantin Taj +1-->
-        <item offset="86" id="11299" /> <!--Pantin Tobe +1-->
-        <item offset="87" id="15032" /> <!--Pantin Dastanas +1-->
-        <item offset="88" id="16353" /> <!--Ptn. Churidars +1-->
-        <item offset="89" id="11389" /> <!--Ptn. Babouches +1-->
-        <item offset="90" id="11479" /> <!--Etoile Tiara +1-->
-        <item offset="91" id="11306" /> <!--Etoile Casaque +1-->
-        <item offset="92" id="15039" /> <!--Etoile Bangles +1-->
-        <item offset="93" id="16361" /> <!--Etoile Tights +1-->
-        <item offset="94" id="11397" /> <!--Etoile Toe Shoes +1-->
-        <item offset="95" id="11481" /> <!--Argute M.board +1-->
-        <item offset="96" id="11308" /> <!--Argute Gown +1-->
-        <item offset="97" id="15041" /> <!--Argute Bracers +1-->
-        <item offset="98" id="16363" /> <!--Argute Pants +1-->
-        <item offset="99" id="11399" /> <!--Argute Loafers +1-->
-    </slip>
-    <slip id="29319">
-        <item offset="0" id="12008" /> <!--Ravager's Mask-->
-        <item offset="1" id="12028" /> <!--Ravager's Lorica-->
-        <item offset="2" id="12048" /> <!--Ravager's Mufflers-->
-        <item offset="3" id="12068" /> <!--Ravager's Cuisses-->
-        <item offset="4" id="12088" /> <!--Ravager's Calligae-->
-        <item offset="5" id="11591" /> <!--Ravager's Gorget-->
-        <item offset="6" id="19253" /> <!--Ravager's Orb-->
-        <item offset="7" id="12009" /> <!--Tantra Crown-->
-        <item offset="8" id="12029" /> <!--Tantra Cyclas-->
-        <item offset="9" id="12049" /> <!--Tantra Gloves-->
-        <item offset="10" id="12069" /> <!--Tantra Hose-->
-        <item offset="11" id="12089" /> <!--Tantra Gaiters-->
-        <item offset="12" id="11592" /> <!--Tantra Necklace-->
-        <item offset="13" id="19254" /> <!--Tantra Tathlum-->
-        <item offset="14" id="12010" /> <!--Orison Cap-->
-        <item offset="15" id="12030" /> <!--Orison Bliaut-->
-        <item offset="16" id="12050" /> <!--Orison Mitts-->
-        <item offset="17" id="12070" /> <!--Orison Pantaloons-->
-        <item offset="18" id="12090" /> <!--Orison Duckbills-->
-        <item offset="19" id="11615" /> <!--Orison Locket-->
-        <item offset="20" id="11554" /> <!--Orison Cape-->
-        <item offset="21" id="12011" /> <!--Goetia Petasos-->
-        <item offset="22" id="12031" /> <!--Goetia Coat-->
-        <item offset="23" id="12051" /> <!--Goetia Gloves-->
-        <item offset="24" id="12071" /> <!--Goetia Chausses-->
-        <item offset="25" id="12091" /> <!--Goetia Sabots-->
-        <item offset="26" id="11593" /> <!--Goetia Chain-->
-        <item offset="27" id="16203" /> <!--Goetia Mantle-->
-        <item offset="28" id="12012" /> <!--Estq. Chappel-->
-        <item offset="29" id="12032" /> <!--Estoqueur's Sayon-->
-        <item offset="30" id="12052" /> <!--Estq. Gantherots-->
-        <item offset="31" id="12072" /> <!--Estq. Fuseau-->
-        <item offset="32" id="12092" /> <!--Estq. Houseaux-->
-        <item offset="33" id="11594" /> <!--Estoqueur's Collar-->
-        <item offset="34" id="16204" /> <!--Estoqueur's Cape-->
-        <item offset="35" id="12013" /> <!--Raider's Bonnet-->
-        <item offset="36" id="12033" /> <!--Raider's Vest-->
-        <item offset="37" id="12053" /> <!--Raider's Armlets-->
-        <item offset="38" id="12073" /> <!--Raider's Culottes-->
-        <item offset="39" id="12093" /> <!--Raider's Poulaines-->
-        <item offset="40" id="11736" /> <!--Raider's Belt-->
-        <item offset="41" id="19260" /> <!--Raider's Bmrng.-->
-        <item offset="42" id="12014" /> <!--Creed Armet-->
-        <item offset="43" id="12034" /> <!--Creed Cuirass-->
-        <item offset="44" id="12054" /> <!--Creed Gauntlets-->
-        <item offset="45" id="12074" /> <!--Creed Cuisses-->
-        <item offset="46" id="12094" /> <!--Creed Sabatons-->
-        <item offset="47" id="11595" /> <!--Creed Collar-->
-        <item offset="48" id="11750" /> <!--Creed Baudrier-->
-        <item offset="49" id="12015" /> <!--Bale Burgeonet-->
-        <item offset="50" id="12035" /> <!--Bale Cuirass-->
-        <item offset="51" id="12055" /> <!--Bale Gauntlets-->
-        <item offset="52" id="12075" /> <!--Bale Flanchard-->
-        <item offset="53" id="12095" /> <!--Bale Sollerets-->
-        <item offset="54" id="11616" /> <!--Bale Choker-->
-        <item offset="55" id="11737" /> <!--Bale Belt-->
-        <item offset="56" id="12016" /> <!--Ferine Cabasset-->
-        <item offset="57" id="12036" /> <!--Ferine Gausape-->
-        <item offset="58" id="12056" /> <!--Ferine Manoplas-->
-        <item offset="59" id="12076" /> <!--Ferine Quijotes-->
-        <item offset="60" id="12096" /> <!--Ferine Ocreae-->
-        <item offset="61" id="11617" /> <!--Ferine Necklace-->
-        <item offset="62" id="11555" /> <!--Ferine Mantle-->
-        <item offset="63" id="12017" /> <!--Aoidos' Calot-->
-        <item offset="64" id="12037" /> <!--Aoidos' Hongreline-->
-        <item offset="65" id="12057" /> <!--Aoidos' Mnchtte.-->
-        <item offset="66" id="12077" /> <!--Aoidos' Rhingrave-->
-        <item offset="67" id="12097" /> <!--Aoidos' Cothurnes-->
-        <item offset="68" id="11618" /> <!--Aoidos' Matinee-->
-        <item offset="69" id="11738" /> <!--Aoidos' Belt-->
-        <item offset="70" id="12018" /> <!--Sylvan Gapette-->
-        <item offset="71" id="12038" /> <!--Sylvan Caban-->
-        <item offset="72" id="12058" /> <!--Syl. Glovelettes-->
-        <item offset="73" id="12078" /> <!--Sylvan Bragues-->
-        <item offset="74" id="12098" /> <!--Sylvan Bottillons-->
-        <item offset="75" id="11596" /> <!--Sylvan Scarf-->
-        <item offset="76" id="16205" /> <!--Sylvan Chlamys-->
-        <item offset="77" id="12019" /> <!--Unkai Kabuto-->
-        <item offset="78" id="12039" /> <!--Unkai Domaru-->
-        <item offset="79" id="12059" /> <!--Unkai Kote-->
-        <item offset="80" id="12079" /> <!--Unkai Haidate-->
-        <item offset="81" id="12099" /> <!--Unkai Sune-Ate-->
-        <item offset="82" id="11597" /> <!--Unkai Nodowa-->
-        <item offset="83" id="16206" /> <!--Unkai Sugemino-->
-        <item offset="84" id="12020" /> <!--Iga Zukin-->
-        <item offset="85" id="12040" /> <!--Iga Ningi-->
-        <item offset="86" id="12060" /> <!--Iga Tekko-->
-        <item offset="87" id="12080" /> <!--Iga Hakama-->
-        <item offset="88" id="12100" /> <!--Iga Kyahan-->
-        <item offset="89" id="11598" /> <!--Iga Erimaki-->
-        <item offset="90" id="16207" /> <!--Iga Dochugappa-->
-        <item offset="91" id="12021" /> <!--Lancer's Mezail-->
-        <item offset="92" id="12041" /> <!--Lncr. Plackart-->
-        <item offset="93" id="12061" /> <!--Lancer's Vambraces-->
-        <item offset="94" id="12081" /> <!--Lancer's Cuissots-->
-        <item offset="95" id="12101" /> <!--Lncr. Schynbalds-->
-        <item offset="96" id="11599" /> <!--Lancer's Torque-->
-        <item offset="97" id="16208" /> <!--Lancer's Pelerine-->
-        <item offset="98" id="12022" /> <!--Caller's Horn-->
-        <item offset="99" id="12042" /> <!--Caller's Doublet-->
-        <item offset="100" id="12062" /> <!--Caller's Bracers-->
-        <item offset="101" id="12082" /> <!--Caller's Spats-->
-        <item offset="102" id="12102" /> <!--Caller's Pigaches-->
-        <item offset="103" id="11619" /> <!--Caller's Pendant-->
-        <item offset="104" id="11739" /> <!--Caller's Sash-->
-        <item offset="105" id="12023" /> <!--Mavi Kavuk-->
-        <item offset="106" id="12043" /> <!--Mavi Mintan-->
-        <item offset="107" id="12063" /> <!--Mavi Bazubands-->
-        <item offset="108" id="12083" /> <!--Mavi Tayt-->
-        <item offset="109" id="12103" /> <!--Mavi Basmak-->
-        <item offset="110" id="11600" /> <!--Mavi Scarf-->
-        <item offset="111" id="19255" /> <!--Mavi Tathlum-->
-        <item offset="112" id="12024" /> <!--Navarch's Tricorne-->
-        <item offset="113" id="12044" /> <!--Navarch's Frac-->
-        <item offset="114" id="12064" /> <!--Navarch's Gants-->
-        <item offset="115" id="12084" /> <!--Navarch's Culottes-->
-        <item offset="116" id="12104" /> <!--Navarch's Bottes-->
-        <item offset="117" id="11601" /> <!--Navarch's Choker-->
-        <item offset="118" id="16209" /> <!--Navarch's Mantle-->
-        <item offset="119" id="12025" /> <!--Cirque Cappello-->
-        <item offset="120" id="12045" /> <!--Cirque Farsetto-->
-        <item offset="121" id="12065" /> <!--Cirque Guanti-->
-        <item offset="122" id="12085" /> <!--Cirque Pantaloni-->
-        <item offset="123" id="12105" /> <!--Cirque Scarpe-->
-        <item offset="124" id="11602" /> <!--Cirque Necklace-->
-        <item offset="125" id="11751" /> <!--Cirque Sash-->
-        <item offset="126" id="12026" /> <!--Charis Tiara-->
-        <item offset="127" id="12046" /> <!--Charis Casaque-->
-        <item offset="128" id="12066" /> <!--Charis Bangles-->
-        <item offset="129" id="12086" /> <!--Charis Tights-->
-        <item offset="130" id="12106" /> <!--Charis Toe Shoes-->
-        <item offset="131" id="11603" /> <!--Charis Necklace-->
-        <item offset="132" id="19256" /> <!--Charis Feather-->
-        <item offset="133" id="12027" /> <!--Savant's Bonnet-->
-        <item offset="134" id="12047" /> <!--Savant's Gown-->
-        <item offset="135" id="12067" /> <!--Savant's Bracers-->
-        <item offset="136" id="12087" /> <!--Savant's Pants-->
-        <item offset="137" id="12107" /> <!--Savant's Loafers-->
-        <item offset="138" id="11620" /> <!--Savant's Chain-->
-        <item offset="139" id="19247" /> <!--Savant's Treatise-->
-        <item offset="140" id="11703" /> <!--Ravager's Earring-->
-        <item offset="141" id="11704" /> <!--Tantra Earring-->
-        <item offset="142" id="11705" /> <!--Orison Earring-->
-        <item offset="143" id="11706" /> <!--Goetia Earring-->
-        <item offset="144" id="11707" /> <!--Estq. Earring-->
-        <item offset="145" id="11708" /> <!--Raider's Earring-->
-        <item offset="146" id="11709" /> <!--Creed Earring-->
-        <item offset="147" id="11710" /> <!--Bale Earring-->
-        <item offset="148" id="11711" /> <!--Ferine Earring-->
-        <item offset="149" id="11712" /> <!--Aoidos' Earring-->
-        <item offset="150" id="11713" /> <!--Sylvan Earring-->
-        <item offset="151" id="11714" /> <!--Unkai Mimikazari-->
-        <item offset="152" id="11715" /> <!--Iga Mimikazari-->
-        <item offset="153" id="11716" /> <!--Lancer's Earring-->
-        <item offset="154" id="11717" /> <!--Caller's Earring-->
-        <item offset="155" id="11718" /> <!--Mavi Earring-->
-        <item offset="156" id="11719" /> <!--Navarch's Earring-->
-        <item offset="157" id="11720" /> <!--Cirque Earring-->
-        <item offset="158" id="11721" /> <!--Charis Earring-->
-        <item offset="159" id="11722" /> <!--Savant's Earring-->
-    </slip>
-    <slip id="29320">
-        <item offset="0" id="11164" /> <!--Ravager's Mask +1-->
-        <item offset="1" id="11184" /> <!--Rvg. Lorica +1-->
-        <item offset="2" id="11204" /> <!--Rvg. Mufflers +1-->
-        <item offset="3" id="11224" /> <!--Rvg. Cuisses +1-->
-        <item offset="4" id="11244" /> <!--Rvg. Calligae +1-->
-        <item offset="5" id="11165" /> <!--Tantra Crown +1-->
-        <item offset="6" id="11185" /> <!--Tantra Cyclas +1-->
-        <item offset="7" id="11205" /> <!--Tantra Gloves +1-->
-        <item offset="8" id="11225" /> <!--Tantra Hose +1-->
-        <item offset="9" id="11245" /> <!--Tantra Gaiters +1-->
-        <item offset="10" id="11166" /> <!--Orison Cap +1-->
-        <item offset="11" id="11186" /> <!--Orison Bliaut +1-->
-        <item offset="12" id="11206" /> <!--Orison Mitts +1-->
-        <item offset="13" id="11226" /> <!--Orsn. Pantaln. +1-->
-        <item offset="14" id="11246" /> <!--Orsn. Duckbills +1-->
-        <item offset="15" id="11167" /> <!--Goetia Petasos +1-->
-        <item offset="16" id="11187" /> <!--Goetia Coat +1-->
-        <item offset="17" id="11207" /> <!--Goetia Gloves +1-->
-        <item offset="18" id="11227" /> <!--Goet. Chausses +1-->
-        <item offset="19" id="11247" /> <!--Goetia Sabots +1-->
-        <item offset="20" id="11168" /> <!--Estq. Chappel +1-->
-        <item offset="21" id="11188" /> <!--Estq. Sayon +1-->
-        <item offset="22" id="11208" /> <!--Estq. Ganthrt. +1-->
-        <item offset="23" id="11228" /> <!--Estqr. Fuseau +1-->
-        <item offset="24" id="11248" /> <!--Estq. Houseaux +1-->
-        <item offset="25" id="11169" /> <!--Raid. Bonnet +1-->
-        <item offset="26" id="11189" /> <!--Raider's Vest +1-->
-        <item offset="27" id="11209" /> <!--Raid. Armlets +1-->
-        <item offset="28" id="11229" /> <!--Raid. Culottes +1-->
-        <item offset="29" id="11249" /> <!--Raid. Poulaines +1-->
-        <item offset="30" id="11170" /> <!--Creed Armet +1-->
-        <item offset="31" id="11190" /> <!--Creed Cuirass +1-->
-        <item offset="32" id="11210" /> <!--Crd. Gauntlets +1-->
-        <item offset="33" id="11230" /> <!--Creed Cuisses +1-->
-        <item offset="34" id="11250" /> <!--Creed Sabatons +1-->
-        <item offset="35" id="11171" /> <!--Bale Burgeonet +1-->
-        <item offset="36" id="11191" /> <!--Bale Cuirass +1-->
-        <item offset="37" id="11211" /> <!--Bale Gauntlets +1-->
-        <item offset="38" id="11231" /> <!--Bale Flanchard +1-->
-        <item offset="39" id="11251" /> <!--Bale Sollerets +1-->
-        <item offset="40" id="11172" /> <!--Ferine Cabasset +1-->
-        <item offset="41" id="11192" /> <!--Ferine Gausape +1-->
-        <item offset="42" id="11212" /> <!--Frn. Manoplas +1-->
-        <item offset="43" id="11232" /> <!--Ferine Quijotes +1-->
-        <item offset="44" id="11252" /> <!--Ferine Ocreae +1-->
-        <item offset="45" id="11173" /> <!--Aoidos' Calot +1-->
-        <item offset="46" id="11193" /> <!--Aoidos' Hngrln. +1-->
-        <item offset="47" id="11213" /> <!--Ad. Mnchtte. +1-->
-        <item offset="48" id="11233" /> <!--Aoidos' Rhing. +1-->
-        <item offset="49" id="11253" /> <!--Aoidos' Cothrn. +1-->
-        <item offset="50" id="11174" /> <!--Sylvan Gapette +1-->
-        <item offset="51" id="11194" /> <!--Sylvan Caban +1-->
-        <item offset="52" id="11214" /> <!--Syl. Glvltte. +1-->
-        <item offset="53" id="11234" /> <!--Sylvan Bragues +1-->
-        <item offset="54" id="11254" /> <!--Sylvan Bottln. +1-->
-        <item offset="55" id="11175" /> <!--Unkai Kabuto +1-->
-        <item offset="56" id="11195" /> <!--Unkai Domaru +1-->
-        <item offset="57" id="11215" /> <!--Unkai Kote +1-->
-        <item offset="58" id="11235" /> <!--Unkai Haidate +1-->
-        <item offset="59" id="11255" /> <!--Unkai Sune-Ate +1-->
-        <item offset="60" id="11176" /> <!--Iga Zukin +1-->
-        <item offset="61" id="11196" /> <!--Iga Ningi +1-->
-        <item offset="62" id="11216" /> <!--Iga Tekko +1-->
-        <item offset="63" id="11236" /> <!--Iga Hakama +1-->
-        <item offset="64" id="11256" /> <!--Iga Kyahan +1-->
-        <item offset="65" id="11177" /> <!--Lancer's Mezail +1-->
-        <item offset="66" id="11197" /> <!--Lncr. Plackart +1-->
-        <item offset="67" id="11217" /> <!--Lncr. Vmbrc. +1-->
-        <item offset="68" id="11237" /> <!--Lncr. Cuissots +1-->
-        <item offset="69" id="11257" /> <!--Lncr. Schynbld. +1-->
-        <item offset="70" id="11178" /> <!--Caller's Horn +1-->
-        <item offset="71" id="11198" /> <!--Caller's Doublet +1-->
-        <item offset="72" id="11218" /> <!--Caller's Bracers +1-->
-        <item offset="73" id="11238" /> <!--Caller's Spats +1-->
-        <item offset="74" id="11258" /> <!--Caller's Pgch. +1-->
-        <item offset="75" id="11179" /> <!--Mavi Kavuk +1-->
-        <item offset="76" id="11199" /> <!--Mavi Mintan +1-->
-        <item offset="77" id="11219" /> <!--Mv. Bazubands +1-->
-        <item offset="78" id="11239" /> <!--Mavi Tayt +1-->
-        <item offset="79" id="11259" /> <!--Mavi Basmak +1-->
-        <item offset="80" id="11180" /> <!--Nvrch. Tricorne +1-->
-        <item offset="81" id="11200" /> <!--Navarch's Frac +1-->
-        <item offset="82" id="11220" /> <!--Nvrch. Gants +1-->
-        <item offset="83" id="11240" /> <!--Nvrch. Culottes +1-->
-        <item offset="84" id="11260" /> <!--Nvrch. Bottes +1-->
-        <item offset="85" id="11181" /> <!--Cirque Cappello +1-->
-        <item offset="86" id="11201" /> <!--Cirque Farsetto +1-->
-        <item offset="87" id="11221" /> <!--Cirque Guanti +1-->
-        <item offset="88" id="11241" /> <!--Cirq. Pantaloni +1-->
-        <item offset="89" id="11261" /> <!--Cirque Scarpe +1-->
-        <item offset="90" id="11182" /> <!--Charis Tiara +1-->
-        <item offset="91" id="11202" /> <!--Charis Casaque +1-->
-        <item offset="92" id="11222" /> <!--Charis Bangles +1-->
-        <item offset="93" id="11242" /> <!--Charis Tights +1-->
-        <item offset="94" id="11262" /> <!--Charis Toe Shoes +1-->
-        <item offset="95" id="11183" /> <!--Svnt. Bonnet +1-->
-        <item offset="96" id="11203" /> <!--Savant's Gown +1-->
-        <item offset="97" id="11223" /> <!--Svnt. Bracers +1-->
-        <item offset="98" id="11243" /> <!--Savant's Pants +1-->
-        <item offset="99" id="11263" /> <!--Svnt. Loafers +1-->
-    </slip>
-    <slip id="29321">
-        <item offset="0" id="11064" /> <!--Ravager's Mask +2-->
-        <item offset="1" id="11084" /> <!--Rvg. Lorica +2-->
-        <item offset="2" id="11104" /> <!--Rvg. Mufflers +2-->
-        <item offset="3" id="11124" /> <!--Rvg. Cuisses +2-->
-        <item offset="4" id="11144" /> <!--Rvg. Calligae +2-->
-        <item offset="5" id="11065" /> <!--Tantra Crown +2-->
-        <item offset="6" id="11085" /> <!--Tantra Cyclas +2-->
-        <item offset="7" id="11105" /> <!--Tantra Gloves +2-->
-        <item offset="8" id="11125" /> <!--Tantra Hose +2-->
-        <item offset="9" id="11145" /> <!--Tantra Gaiters +2-->
-        <item offset="10" id="11066" /> <!--Orison Cap +2-->
-        <item offset="11" id="11086" /> <!--Orison Bliaut +2-->
-        <item offset="12" id="11106" /> <!--Orison Mitts +2-->
-        <item offset="13" id="11126" /> <!--Orsn. Pantaln. +2-->
-        <item offset="14" id="11146" /> <!--Orsn. Duckbills +2-->
-        <item offset="15" id="11067" /> <!--Goetia Petasos +2-->
-        <item offset="16" id="11087" /> <!--Goetia Coat +2-->
-        <item offset="17" id="11107" /> <!--Goetia Gloves +2-->
-        <item offset="18" id="11127" /> <!--Goet. Chausses +2-->
-        <item offset="19" id="11147" /> <!--Goetia Sabots +2-->
-        <item offset="20" id="11068" /> <!--Estq. Chappel +2-->
-        <item offset="21" id="11088" /> <!--Estq. Sayon +2-->
-        <item offset="22" id="11108" /> <!--Estq. Ganthrt. +2-->
-        <item offset="23" id="11128" /> <!--Estqr. Fuseau +2-->
-        <item offset="24" id="11148" /> <!--Estq. Houseaux +2-->
-        <item offset="25" id="11069" /> <!--Raid. Bonnet +2-->
-        <item offset="26" id="11089" /> <!--Raider's Vest +2-->
-        <item offset="27" id="11109" /> <!--Raid. Armlets +2-->
-        <item offset="28" id="11129" /> <!--Raid. Culottes +2-->
-        <item offset="29" id="11149" /> <!--Raid. Poulaines +2-->
-        <item offset="30" id="11070" /> <!--Creed Armet +2-->
-        <item offset="31" id="11090" /> <!--Creed Cuirass +2-->
-        <item offset="32" id="11110" /> <!--Crd. Gauntlets +2-->
-        <item offset="33" id="11130" /> <!--Creed Cuisses +2-->
-        <item offset="34" id="11150" /> <!--Creed Sabatons +2-->
-        <item offset="35" id="11071" /> <!--Bale Burgeonet +2-->
-        <item offset="36" id="11091" /> <!--Bale Cuirass +2-->
-        <item offset="37" id="11111" /> <!--Bale Gauntlets +2-->
-        <item offset="38" id="11131" /> <!--Bale Flanchard +2-->
-        <item offset="39" id="11151" /> <!--Bale Sollerets +2-->
-        <item offset="40" id="11072" /> <!--Ferine Cabasset +2-->
-        <item offset="41" id="11092" /> <!--Ferine Gausape +2-->
-        <item offset="42" id="11112" /> <!--Frn. Manoplas +2-->
-        <item offset="43" id="11132" /> <!--Ferine Quijotes +2-->
-        <item offset="44" id="11152" /> <!--Ferine Ocreae +2-->
-        <item offset="45" id="11073" /> <!--Aoidos' Calot +2-->
-        <item offset="46" id="11093" /> <!--Aoidos' Hngrln. +2-->
-        <item offset="47" id="11113" /> <!--Ad. Mnchtte. +2-->
-        <item offset="48" id="11133" /> <!--Aoidos' Rhing. +2-->
-        <item offset="49" id="11153" /> <!--Aoidos' Cothrn. +2-->
-        <item offset="50" id="11074" /> <!--Sylvan Gapette +2-->
-        <item offset="51" id="11094" /> <!--Sylvan Caban +2-->
-        <item offset="52" id="11114" /> <!--Syl. Glvltte. +2-->
-        <item offset="53" id="11134" /> <!--Sylvan Bragues +2-->
-        <item offset="54" id="11154" /> <!--Sylvan Bottln. +2-->
-        <item offset="55" id="11075" /> <!--Unkai Kabuto +2-->
-        <item offset="56" id="11095" /> <!--Unkai Domaru +2-->
-        <item offset="57" id="11115" /> <!--Unkai Kote +2-->
-        <item offset="58" id="11135" /> <!--Unkai Haidate +2-->
-        <item offset="59" id="11155" /> <!--Unkai Sune-Ate +2-->
-        <item offset="60" id="11076" /> <!--Iga Zukin +2-->
-        <item offset="61" id="11096" /> <!--Iga Ningi +2-->
-        <item offset="62" id="11116" /> <!--Iga Tekko +2-->
-        <item offset="63" id="11136" /> <!--Iga Hakama +2-->
-        <item offset="64" id="11156" /> <!--Iga Kyahan +2-->
-        <item offset="65" id="11077" /> <!--Lancer's Mezail +2-->
-        <item offset="66" id="11097" /> <!--Lncr. Plackart +2-->
-        <item offset="67" id="11117" /> <!--Lncr. Vmbrc. +2-->
-        <item offset="68" id="11137" /> <!--Lncr. Cuissots +2-->
-        <item offset="69" id="11157" /> <!--Lncr. Schynbld. +2-->
-        <item offset="70" id="11078" /> <!--Caller's Horn +2-->
-        <item offset="71" id="11098" /> <!--Call. Doublet +2-->
-        <item offset="72" id="11118" /> <!--Call. Bracers +2-->
-        <item offset="73" id="11138" /> <!--Caller's Spats +2-->
-        <item offset="74" id="11158" /> <!--Caller's Pgch. +2-->
-        <item offset="75" id="11079" /> <!--Mavi Kavuk +2-->
-        <item offset="76" id="11099" /> <!--Mavi Mintan +2-->
-        <item offset="77" id="11119" /> <!--Mv. Bazubands +2-->
-        <item offset="78" id="11139" /> <!--Mavi Tayt +2-->
-        <item offset="79" id="11159" /> <!--Mavi Basmak +2-->
-        <item offset="80" id="11080" /> <!--Nvrch. Tricorne +2-->
-        <item offset="81" id="11100" /> <!--Nvrch. Frac +2-->
-        <item offset="82" id="11120" /> <!--Nvrch. Gants +2-->
-        <item offset="83" id="11140" /> <!--Nvrch. Culottes +2-->
-        <item offset="84" id="11160" /> <!--Nvrch. Bottes +2-->
-        <item offset="85" id="11081" /> <!--Cirque Cappello +2-->
-        <item offset="86" id="11101" /> <!--Cirque Farsetto +2-->
-        <item offset="87" id="11121" /> <!--Cirque Guanti +2-->
-        <item offset="88" id="11141" /> <!--Cirq. Pantaloni +2-->
-        <item offset="89" id="11161" /> <!--Cirque Scarpe +2-->
-        <item offset="90" id="11082" /> <!--Charis Tiara +2-->
-        <item offset="91" id="11102" /> <!--Charis Casaque +2-->
-        <item offset="92" id="11122" /> <!--Charis Bangles +2-->
-        <item offset="93" id="11142" /> <!--Charis Tights +2-->
-        <item offset="94" id="11162" /> <!--Charis Toe Shoes +2-->
-        <item offset="95" id="11083" /> <!--Svnt. Bonnet +2-->
-        <item offset="96" id="11103" /> <!--Savant's Gown +2-->
-        <item offset="97" id="11123" /> <!--Svnt. Bracers +2-->
-        <item offset="98" id="11143" /> <!--Savant's Pants +2-->
-        <item offset="99" id="11163" /> <!--Svnt. Loafers +2-->
-    </slip>
-    <slip id="29322">
-        <item offset="0" id="15297" /> <!--Rabbit Belt-->
-        <item offset="1" id="15298" /> <!--Worm Belt-->
-        <item offset="2" id="15299" /> <!--Mandragora Belt-->
-        <item offset="3" id="15919" /> <!--Drover's Belt-->
-        <item offset="4" id="15929" /> <!--Goblin Belt-->
-        <item offset="5" id="15921" /> <!--Detonator Belt-->
-        <item offset="6" id="18871" /> <!--Kitty Rod-->
-        <item offset="7" id="16273" /> <!--Pullus Torque-->
-        <item offset="8" id="18166" /> <!--Happy Egg-->
-        <item offset="9" id="18167" /> <!--Fortune Egg-->
-        <item offset="10" id="18256" /> <!--Orphic Egg-->
-        <item offset="11" id="13216" /> <!--Gold Mog. Belt-->
-        <item offset="12" id="13217" /> <!--Silver Mog. Belt-->
-        <item offset="13" id="13218" /> <!--Bronze Mog. Belt-->
-        <item offset="14" id="15455" /> <!--Red Sash-->
-        <item offset="15" id="15456" /> <!--Dash Sash-->
-        <item offset="16" id="181" /> <!--San d'Orian Flag-->
-        <item offset="17" id="182" /> <!--Bastokan Flag-->
-        <item offset="18" id="183" /> <!--Windurstian Flag-->
-        <item offset="19" id="184" /> <!--Jeunoan Flag-->
-        <item offset="20" id="129" /> <!--Imperial Standard-->
-        <item offset="21" id="11499" /> <!--Trainee's Specs.-->
-        <item offset="22" id="18502" /> <!--Trainee Axe-->
-        <item offset="23" id="18855" /> <!--Trainee Hammer-->
-        <item offset="24" id="19274" /> <!--Trainee Burin-->
-        <item offset="25" id="18763" /> <!--Trainee Scissors-->
-        <item offset="26" id="19110" /> <!--Trainee's Needle-->
-        <item offset="27" id="15008" /> <!--Trainee Gloves-->
-        <item offset="28" id="17764" /> <!--Trainee Sword-->
-        <item offset="29" id="19101" /> <!--Trainee Knife-->
-        <item offset="30" id="365" /> <!--Poele Classique-->
-        <item offset="31" id="366" /> <!--Kanonenofen-->
-        <item offset="32" id="367" /> <!--Pot Topper-->
-        <item offset="33" id="15860" /> <!--Gyokuto Obi-->
-        <item offset="34" id="272" /> <!--A.Angel HM Stat.-->
-        <item offset="35" id="273" /> <!--A.Angel EV Stat.-->
-        <item offset="36" id="274" /> <!--A.Angel TT Stat.-->
-        <item offset="37" id="275" /> <!--A.Angel MR Stat.-->
-        <item offset="38" id="276" /> <!--A.Angel GK Stat.-->
-        <item offset="39" id="11853" /> <!--Novennial Coat-->
-        <item offset="40" id="11956" /> <!--Novennial Hose-->
-        <item offset="41" id="11854" /> <!--Novennial Dress-->
-        <item offset="42" id="11957" /> <!--Novennial Boots-->
-        <item offset="43" id="11811" /> <!--Destrier Beret-->
-        <item offset="44" id="11812" /> <!--Charity Cap-->
-        <item offset="45" id="11861" /> <!--Hikogami Yukata-->
-        <item offset="46" id="11862" /> <!--Himegami Yukata-->
-        <item offset="47" id="3676" /> <!--Celestial Globe-->
-        <item offset="48" id="18879" /> <!--Rounsey Wand-->
-        <item offset="49" id="3647" /> <!--Spook-a-Swirl-->
-        <item offset="50" id="3648" /> <!--Choc. Grumpkin-->
-        <item offset="51" id="3649" /> <!--Harvest Horror-->
-        <item offset="52" id="3677" /> <!--Spinet-->
-        <item offset="53" id="18880" /> <!--Maestro's Baton-->
-        <item offset="54" id="18863" /> <!--Dream Bell-->
-        <item offset="55" id="18864" /> <!--Dream Bell +1-->
-        <item offset="56" id="15178" /> <!--Dream Hat-->
-        <item offset="57" id="14519" /> <!--Dream Robe-->
-        <item offset="58" id="10382" /> <!--Dream Mittens-->
-        <item offset="59" id="11965" /> <!--Dream Trousers-->
-        <item offset="60" id="11967" /> <!--Dream Pants-->
-        <item offset="61" id="15752" /> <!--Dream Boots-->
-        <item offset="62" id="15179" /> <!--Dream Hat +1-->
-        <item offset="63" id="14520" /> <!--Dream Robe +1-->
-        <item offset="64" id="10383" /> <!--Dream Mittens +1-->
-        <item offset="65" id="11966" /> <!--Dream Trousers +1-->
-        <item offset="66" id="11968" /> <!--Dream Pants +1-->
-        <item offset="67" id="15753" /> <!--Dream Boots +1-->
-        <item offset="68" id="10875" /> <!--Snowman Cap-->
-        <item offset="69" id="3619" /> <!--Cour. des Etoiles-->
-        <item offset="70" id="3620" /> <!--Silberkranz-->
-        <item offset="71" id="3621" /> <!--Leafberry Wreath-->
-        <item offset="72" id="3650" /> <!--Prinseggstarta-->
-        <item offset="73" id="3652" /> <!--Memorial Cake-->
-        <item offset="74" id="10430" /> <!--Decennial Crown-->
-        <item offset="75" id="10251" /> <!--Decennial Coat-->
-        <item offset="76" id="10593" /> <!--Decennial Tights-->
-        <item offset="77" id="10431" /> <!--Decennial Tiara-->
-        <item offset="78" id="10252" /> <!--Decennial Dress-->
-        <item offset="79" id="10594" /> <!--Decennial Hose-->
-        <item offset="80" id="10432" /> <!--Decennial Crown +1-->
-        <item offset="81" id="10253" /> <!--Decennial Coat +1-->
-        <item offset="82" id="10595" /> <!--Decennial Tights +1-->
-        <item offset="83" id="10433" /> <!--Decennial Tiara +1-->
-        <item offset="84" id="10254" /> <!--Decennial Dress +1-->
-        <item offset="85" id="10596" /> <!--Decennial Hose +1-->
-        <item offset="86" id="10429" /> <!--Moogle Masque-->
-        <item offset="87" id="10250" /> <!--Moogle Suit-->
-        <item offset="88" id="17031" /> <!--Shell Scepter-->
-        <item offset="89" id="17032" /> <!--Gobbie Gavel-->
-        <item offset="90" id="10807" /> <!--Mandraguard-->
-        <item offset="91" id="18881" /> <!--Melomane Mallet-->
-        <item offset="92" id="10256" /> <!--Marine Gilet-->
-        <item offset="93" id="10330" /> <!--Marine Boxers-->
-        <item offset="94" id="10257" /> <!--Marine Top-->
-        <item offset="95" id="10331" /> <!--Marine Shorts-->
-        <item offset="96" id="10258" /> <!--Woodsy Gilet-->
-        <item offset="97" id="10332" /> <!--Woodsy Boxers-->
-        <item offset="98" id="10259" /> <!--Woodsy Top-->
-        <item offset="99" id="10333" /> <!--Woodsy Shorts-->
-        <item offset="100" id="10260" /> <!--Creek Maillot-->
-        <item offset="101" id="10334" /> <!--Creek Boxers-->
-        <item offset="102" id="10261" /> <!--Creek Top-->
-        <item offset="103" id="10335" /> <!--Creek Shorts-->
-        <item offset="104" id="10262" /> <!--River Top-->
-        <item offset="105" id="10336" /> <!--River Shorts-->
-        <item offset="106" id="10263" /> <!--Dune Gilet-->
-        <item offset="107" id="10337" /> <!--Dune Boxers-->
-        <item offset="108" id="10264" /> <!--Marine Gilet +1-->
-        <item offset="109" id="10338" /> <!--Marine Boxers +1-->
-        <item offset="110" id="10265" /> <!--Marine Top +1-->
-        <item offset="111" id="10339" /> <!--Marine Shorts +1-->
-        <item offset="112" id="10266" /> <!--Woodsy Gilet +1-->
-        <item offset="113" id="10340" /> <!--Woodsy Boxers +1-->
-        <item offset="114" id="10267" /> <!--Woodsy Top +1-->
-        <item offset="115" id="10341" /> <!--Woodsy Shorts +1-->
-        <item offset="116" id="10268" /> <!--Creek Maillot +1-->
-        <item offset="117" id="10342" /> <!--Creek Boxers +1-->
-        <item offset="118" id="10269" /> <!--Creek Top +1-->
-        <item offset="119" id="10343" /> <!--Creek Shorts +1-->
-        <item offset="120" id="10270" /> <!--River Top +1-->
-        <item offset="121" id="10344" /> <!--River Shorts +1-->
-        <item offset="122" id="10271" /> <!--Dune Gilet +1-->
-        <item offset="123" id="10345" /> <!--Dune Boxers +1-->
-        <item offset="124" id="10446" /> <!--Ahriman Cap-->
-        <item offset="125" id="10447" /> <!--Pyracmon Cap-->
-        <item offset="126" id="426" /> <!--Orchestrion-->
-        <item offset="127" id="10808" /> <!--Janus Guard-->
-        <item offset="128" id="3654" /> <!--Tender Bouquet-->
-        <item offset="129" id="265" /> <!--Adamant. Statue-->
-        <item offset="130" id="266" /> <!--Behemoth Statue-->
-        <item offset="131" id="267" /> <!--Fafnir Statue-->
-        <item offset="132" id="269" /> <!--S. Lord Statue-->
-        <item offset="133" id="270" /> <!--Odin Statue-->
-        <item offset="134" id="271" /> <!--Alexander Statue-->
-        <item offset="135" id="18464" /> <!--Ark Tachi-->
-        <item offset="136" id="18545" /> <!--Ark Tabar-->
-        <item offset="137" id="18563" /> <!--Ark Scythe-->
-        <item offset="138" id="18912" /> <!--Ark Saber-->
-        <item offset="139" id="18913" /> <!--Ark Sword-->
-        <item offset="140" id="10293" /> <!--Chocobo Shirt-->
-        <item offset="141" id="10809" /> <!--Moogle Guard-->
-        <item offset="142" id="10810" /> <!--Moogle Guard +1-->
-        <item offset="143" id="10811" /> <!--Chocobo Shield-->
-        <item offset="144" id="10812" /> <!--Choco. Shield +1-->
-        <item offset="145" id="27803" /> <!--Rustic Maillot-->
-        <item offset="146" id="28086" /> <!--Rustic Trunks-->
-        <item offset="147" id="27804" /> <!--Shoal Maillot-->
-        <item offset="148" id="28087" /> <!--Shoal Trunks-->
-        <item offset="149" id="27805" /> <!--Rustic Maillot +1-->
-        <item offset="150" id="28088" /> <!--Rustic Trunks +1-->
-        <item offset="151" id="27806" /> <!--Shoal Maillot +1-->
-        <item offset="152" id="28089" /> <!--Shoal Trunks +1-->
-        <item offset="153" id="27765" /> <!--Chocobo Masque-->
-        <item offset="154" id="27911" /> <!--Chocobo Suit-->
-        <item offset="155" id="27760" /> <!--Chocobo Masque +1-->
-        <item offset="156" id="27906" /> <!--Chocobo Suit +1-->
-        <item offset="157" id="27759" /> <!--Korrigan Beret-->
-        <item offset="158" id="28661" /> <!--Glinting Shield-->
-        <item offset="159" id="286" /> <!--Nanaa Mihgo Statue-->
-        <item offset="160" id="27757" /> <!--Bomb Masque-->
-        <item offset="161" id="27758" /> <!--Bomb Masque +1-->
-        <item offset="162" id="287" /> <!--Nanaa Mihgo S. II-->
-        <item offset="163" id="27899" /> <!--Alliance Shirt-->
-        <item offset="164" id="28185" /> <!--Alliance Pants-->
-        <item offset="165" id="28324" /> <!--Alliance Boots-->
-        <item offset="166" id="27898" /> <!--Alliance Shirt +1-->
-        <item offset="167" id="28655" /> <!--Slime Shield-->
-        <item offset="168" id="27756" /> <!--Slime Cap-->
-        <item offset="169" id="28511" /> <!--Slime Earring-->
-        <item offset="170" id="21118" /> <!--G. Spriggan Club-->
-        <item offset="171" id="27902" /> <!--G. Spriggan Coat-->
-        <item offset="172" id="100" /> <!--Okadomatsu-->
-        <item offset="173" id="21117" /> <!--Hagoita-->
-        <item offset="174" id="87" /> <!--Kadomatsu-->
-        <item offset="175" id="20953" /> <!--Escritorio-->
-        <item offset="176" id="21280" /> <!--Decazoom Mk-XI-->
-        <item offset="177" id="28652" /> <!--Hatchling Shield-->
-        <item offset="178" id="28650" /> <!--She-Slime Shield-->
-        <item offset="179" id="27726" /> <!--She-Slime Hat-->
-        <item offset="180" id="28509" /> <!--She-Slime Earring-->
-        <item offset="181" id="28651" /> <!--Metal Slime Shield-->
-        <item offset="182" id="27727" /> <!--Metal Slime Hat-->
-        <item offset="183" id="28510" /> <!--M. Slime Earring-->
-        <item offset="184" id="27872" /> <!--P. Spriggan Coat-->
-        <item offset="185" id="21113" /> <!--P. Sprig. Club-->
-        <item offset="186" id="27873" /> <!--R. Spriggan Coat-->
-        <item offset="187" id="21114" /> <!--R. Sprig. Club-->
-        <item offset="188" id="20532" /> <!--Worm Feelers-->
-        <item offset="189" id="20533" /> <!--Worm Feelers +1-->
-        <item offset="190" id="27717" /> <!--Worm Masque-->
-        <item offset="191" id="27718" /> <!--Worm Masque +1-->
-    </slip>
-    <slip id="29323">
-        <item offset="0" id="2033" /> <!--War. Mask -1-->
-        <item offset="1" id="2034" /> <!--War. Lorica -1-->
-        <item offset="2" id="2035" /> <!--War. Mufflers -1-->
-        <item offset="3" id="2036" /> <!--War. Cuisses -1-->
-        <item offset="4" id="2037" /> <!--War. Calligae -1-->
-        <item offset="5" id="2038" /> <!--Mel. Crown -1-->
-        <item offset="6" id="2039" /> <!--Mel. Cyclas -1-->
-        <item offset="7" id="2040" /> <!--Mel. Gloves -1-->
-        <item offset="8" id="2041" /> <!--Mel. Hose -1-->
-        <item offset="9" id="2042" /> <!--Mel. Gaiters -1-->
-        <item offset="10" id="2043" /> <!--Clr. Cap -1-->
-        <item offset="11" id="2044" /> <!--Clr. Bliaut -1-->
-        <item offset="12" id="2045" /> <!--Clr. Mitts -1-->
-        <item offset="13" id="2046" /> <!--Clr. Pantaln. -1-->
-        <item offset="14" id="2047" /> <!--Clr. Duckbills -1-->
-        <item offset="15" id="2048" /> <!--Src. Petasos -1-->
-        <item offset="16" id="2049" /> <!--Src. Coat -1-->
-        <item offset="17" id="2050" /> <!--Src. Gloves -1-->
-        <item offset="18" id="2051" /> <!--Src. Tonban -1-->
-        <item offset="19" id="2052" /> <!--Src. Sabots -1-->
-        <item offset="20" id="2053" /> <!--Dls. Chapeau -1-->
-        <item offset="21" id="2054" /> <!--Dls. Tabard -1-->
-        <item offset="22" id="2055" /> <!--Dls. Gloves -1-->
-        <item offset="23" id="2056" /> <!--Dls. Tights -1-->
-        <item offset="24" id="2057" /> <!--Dls. Boots -1-->
-        <item offset="25" id="2058" /> <!--Asn. Bonnet -1-->
-        <item offset="26" id="2059" /> <!--Asn. Vest -1-->
-        <item offset="27" id="2060" /> <!--Asn. Armlets -1-->
-        <item offset="28" id="2061" /> <!--Asn. Culotte -1-->
-        <item offset="29" id="2062" /> <!--Asn. Poulaines -1-->
-        <item offset="30" id="2063" /> <!--Vlr. Coronet -1-->
-        <item offset="31" id="2064" /> <!--Vlr. Surcoat -1-->
-        <item offset="32" id="2065" /> <!--Vlr. Gauntlets -1-->
-        <item offset="33" id="2066" /> <!--Vlr. Breeches -1-->
-        <item offset="34" id="2067" /> <!--Vlr. Leggings -1-->
-        <item offset="35" id="2068" /> <!--Abs. Burgeonet -1-->
-        <item offset="36" id="2069" /> <!--Abs. Cuirass -1-->
-        <item offset="37" id="2070" /> <!--Abs. Gauntlets -1-->
-        <item offset="38" id="2071" /> <!--Abs. Flanchard -1-->
-        <item offset="39" id="2072" /> <!--Abs. Sollerets -1-->
-        <item offset="40" id="2073" /> <!--Mst. Helm -1-->
-        <item offset="41" id="2074" /> <!--Mst. Jackcoat -1-->
-        <item offset="42" id="2075" /> <!--Mst. Gloves -1-->
-        <item offset="43" id="2076" /> <!--Mst. Trousers -1-->
-        <item offset="44" id="2077" /> <!--Mst. Gaiters -1-->
-        <item offset="45" id="2078" /> <!--Brd. Roundlet -1-->
-        <item offset="46" id="2079" /> <!--Brd. Jstcorps -1-->
-        <item offset="47" id="2080" /> <!--Brd. Cuffs -1-->
-        <item offset="48" id="2081" /> <!--Brd. Cannions -1-->
-        <item offset="49" id="2082" /> <!--Brd. Slippers -1-->
-        <item offset="50" id="2083" /> <!--Sct. Beret -1-->
-        <item offset="51" id="2084" /> <!--Sct. Jerkin -1-->
-        <item offset="52" id="2085" /> <!--Sct. Bracers -1-->
-        <item offset="53" id="2086" /> <!--Sct. Braccae -1-->
-        <item offset="54" id="2087" /> <!--Sct. Socks -1-->
-        <item offset="55" id="2088" /> <!--Sao. Kabuto -1-->
-        <item offset="56" id="2089" /> <!--Sao. Domaru -1-->
-        <item offset="57" id="2090" /> <!--Sao. Kote -1-->
-        <item offset="58" id="2091" /> <!--Sao. Haidate -1-->
-        <item offset="59" id="2092" /> <!--Sao. Sune-Ate -1-->
-        <item offset="60" id="2093" /> <!--Kog. Hatsuburi -1-->
-        <item offset="61" id="2094" /> <!--Kog. Chainmail -1-->
-        <item offset="62" id="2095" /> <!--Kog. Tekko -1-->
-        <item offset="63" id="2096" /> <!--Kog. Hakama -1-->
-        <item offset="64" id="2097" /> <!--Kog. Kyahan -1-->
-        <item offset="65" id="2098" /> <!--Wym. Armet -1-->
-        <item offset="66" id="2099" /> <!--Wym. Mail -1-->
-        <item offset="67" id="2100" /> <!--Wym. Fng. Gnt. -1-->
-        <item offset="68" id="2101" /> <!--Wym. Brais -1-->
-        <item offset="69" id="2102" /> <!--Wym. Greaves -1-->
-        <item offset="70" id="2103" /> <!--Smn. Horn -1-->
-        <item offset="71" id="2104" /> <!--Smn. Doublet -1-->
-        <item offset="72" id="2105" /> <!--Smn. Bracers -1-->
-        <item offset="73" id="2106" /> <!--Smn. Spats -1-->
-        <item offset="74" id="2107" /> <!--Smn. Pigaches -1-->
-        <item offset="75" id="2662" /> <!--Mirage Keffiyeh -1-->
-        <item offset="76" id="2663" /> <!--Mirage Jubbah -1-->
-        <item offset="77" id="2664" /> <!--Mrg. Bazubands -1-->
-        <item offset="78" id="2665" /> <!--Mirage Shalwar -1-->
-        <item offset="79" id="2666" /> <!--Mirage Charuqs -1-->
-        <item offset="80" id="2667" /> <!--Comm. Tricorne -1-->
-        <item offset="81" id="2668" /> <!--Comm. Frac -1-->
-        <item offset="82" id="2669" /> <!--Comm. Gants -1-->
-        <item offset="83" id="2670" /> <!--Comm. Trews -1-->
-        <item offset="84" id="2671" /> <!--Comm. Bottes -1-->
-        <item offset="85" id="2672" /> <!--Pantin Taj -1-->
-        <item offset="86" id="2673" /> <!--Pantin Tobe -1-->
-        <item offset="87" id="2674" /> <!--Ptn. Dastanas -1-->
-        <item offset="88" id="2675" /> <!--Ptn. Churidars -1-->
-        <item offset="89" id="2676" /> <!--Ptn. Babouches -1-->
-        <item offset="90" id="2718" /> <!--Etoile Tiara -1-->
-        <item offset="91" id="2719" /> <!--Etoile Casaque -1-->
-        <item offset="92" id="2720" /> <!--Etoile Bangles -1-->
-        <item offset="93" id="2721" /> <!--Etoile Tights -1-->
-        <item offset="94" id="2722" /> <!--Etoile Toe Shoes -1-->
-        <item offset="95" id="2723" /> <!--Argute M.board -1-->
-        <item offset="96" id="2724" /> <!--Argute Gown -1-->
-        <item offset="97" id="2725" /> <!--Argute Bracers -1-->
-        <item offset="98" id="2726" /> <!--Argute Pants -1-->
-        <item offset="99" id="2727" /> <!--Argute Loafers -1-->
-    </slip>
-    <slip id="29324">
-        <item offset="0" id="10650" /> <!--War. Mask +2-->
-        <item offset="1" id="10670" /> <!--War. Lorica +2-->
-        <item offset="2" id="10690" /> <!--War. Mufflers +2-->
-        <item offset="3" id="10710" /> <!--War. Cuisses +2-->
-        <item offset="4" id="10730" /> <!--War. Calligae +2-->
-        <item offset="5" id="10651" /> <!--Mel. Crown +2-->
-        <item offset="6" id="10671" /> <!--Mel. Cyclas +2-->
-        <item offset="7" id="10691" /> <!--Mel. Gloves +2-->
-        <item offset="8" id="10711" /> <!--Mel. Hose +2-->
-        <item offset="9" id="10731" /> <!--Mel. Gaiters +2-->
-        <item offset="10" id="10652" /> <!--Clr. Cap +2-->
-        <item offset="11" id="10672" /> <!--Clr. Bliaut +2-->
-        <item offset="12" id="10692" /> <!--Clr. Mitts +2-->
-        <item offset="13" id="10712" /> <!--Clr. Pantaln. +2-->
-        <item offset="14" id="10732" /> <!--Clr. Duckbills +2-->
-        <item offset="15" id="10653" /> <!--Src. Petasos +2-->
-        <item offset="16" id="10673" /> <!--Src. Coat +2-->
-        <item offset="17" id="10693" /> <!--Src. Gloves +2-->
-        <item offset="18" id="10713" /> <!--Src. Tonban +2-->
-        <item offset="19" id="10733" /> <!--Src. Sabots +2-->
-        <item offset="20" id="10654" /> <!--Dls. Chapeau +2-->
-        <item offset="21" id="10674" /> <!--Dls. Tabard +2-->
-        <item offset="22" id="10694" /> <!--Dls. Gloves +2-->
-        <item offset="23" id="10714" /> <!--Dls. Tights +2-->
-        <item offset="24" id="10734" /> <!--Dls. Boots +2-->
-        <item offset="25" id="10655" /> <!--Asn. Bonnet +2-->
-        <item offset="26" id="10675" /> <!--Asn. Vest +2-->
-        <item offset="27" id="10695" /> <!--Asn. Armlets +2-->
-        <item offset="28" id="10715" /> <!--Asn. Culottes +2-->
-        <item offset="29" id="10735" /> <!--Asn. Poulaines +2-->
-        <item offset="30" id="10656" /> <!--Vlr. Coronet +2-->
-        <item offset="31" id="10676" /> <!--Vlr. Surcoat +2-->
-        <item offset="32" id="10696" /> <!--Vlr. Gauntlets +2-->
-        <item offset="33" id="10716" /> <!--Vlr. Breeches +2-->
-        <item offset="34" id="10736" /> <!--Vlr. Leggings +2-->
-        <item offset="35" id="10657" /> <!--Abs. Burgeonet +2-->
-        <item offset="36" id="10677" /> <!--Abs. Cuirass +2-->
-        <item offset="37" id="10697" /> <!--Abs. Gauntlets +2-->
-        <item offset="38" id="10717" /> <!--Abs. Flanchard +2-->
-        <item offset="39" id="10737" /> <!--Abs. Sollerets +2-->
-        <item offset="40" id="10658" /> <!--Mst. Helm +2-->
-        <item offset="41" id="10678" /> <!--Mst. Jackcoat +2-->
-        <item offset="42" id="10698" /> <!--Mst. Gloves +2-->
-        <item offset="43" id="10718" /> <!--Mst. Trousers +2-->
-        <item offset="44" id="10738" /> <!--Mst. Gaiters +2-->
-        <item offset="45" id="10659" /> <!--Brd. Roundlet +2-->
-        <item offset="46" id="10679" /> <!--Brd. Jstcorps +2-->
-        <item offset="47" id="10699" /> <!--Brd. Cuffs +2-->
-        <item offset="48" id="10719" /> <!--Brd. Cannions +2-->
-        <item offset="49" id="10739" /> <!--Brd. Slippers +2-->
-        <item offset="50" id="10660" /> <!--Sct. Beret +2-->
-        <item offset="51" id="10680" /> <!--Sct. Jerkin +2-->
-        <item offset="52" id="10700" /> <!--Sct. Bracers +2-->
-        <item offset="53" id="10720" /> <!--Sct. Braccae +2-->
-        <item offset="54" id="10740" /> <!--Sct. Socks +2-->
-        <item offset="55" id="10661" /> <!--Sao. Kabuto +2-->
-        <item offset="56" id="10681" /> <!--Sao. Domaru +2-->
-        <item offset="57" id="10701" /> <!--Sao. Kote +2-->
-        <item offset="58" id="10721" /> <!--Sao. Haidate +2-->
-        <item offset="59" id="10741" /> <!--Sao. Sune-Ate +2-->
-        <item offset="60" id="10662" /> <!--Kog. Hatsuburi +2-->
-        <item offset="61" id="10682" /> <!--Kog. Chainmail +2-->
-        <item offset="62" id="10702" /> <!--Kog. Tekko +2-->
-        <item offset="63" id="10722" /> <!--Kog. Hakama +2-->
-        <item offset="64" id="10742" /> <!--Kog. Kyahan +2-->
-        <item offset="65" id="10663" /> <!--Wym. Armet +2-->
-        <item offset="66" id="10683" /> <!--Wym. Mail +2-->
-        <item offset="67" id="10703" /> <!--Wym. Fng. Gnt. +2-->
-        <item offset="68" id="10723" /> <!--Wym. Brais +2-->
-        <item offset="69" id="10743" /> <!--Wym. Greaves +2-->
-        <item offset="70" id="10664" /> <!--Smn. Horn +2-->
-        <item offset="71" id="10684" /> <!--Smn. Doublet +2-->
-        <item offset="72" id="10704" /> <!--Smn. Bracers +2-->
-        <item offset="73" id="10724" /> <!--Smn. Spats +2-->
-        <item offset="74" id="10744" /> <!--Smn. Pigaches +2-->
-        <item offset="75" id="10665" /> <!--Mirage Keffiyeh +2-->
-        <item offset="76" id="10685" /> <!--Mirage Jubbah +2-->
-        <item offset="77" id="10705" /> <!--Mrg. Bazubands +2-->
-        <item offset="78" id="10725" /> <!--Mirage Shalwar +2-->
-        <item offset="79" id="10745" /> <!--Mirage Charuqs +2-->
-        <item offset="80" id="10666" /> <!--Comm. Tricorne +2-->
-        <item offset="81" id="10686" /> <!--Comm. Frac +2-->
-        <item offset="82" id="10706" /> <!--Comm. Gants +2-->
-        <item offset="83" id="10726" /> <!--Comm. Trews +2-->
-        <item offset="84" id="10746" /> <!--Comm. Bottes +2-->
-        <item offset="85" id="10667" /> <!--Pantin Taj +2-->
-        <item offset="86" id="10687" /> <!--Pantin Tobe +2-->
-        <item offset="87" id="10707" /> <!--Pantin Dastanas +2-->
-        <item offset="88" id="10727" /> <!--Ptn. Churidars +2-->
-        <item offset="89" id="10747" /> <!--Ptn. Babouches +2-->
-        <item offset="90" id="10668" /> <!--Etoile Tiara +2-->
-        <item offset="91" id="10688" /> <!--Etoile Casaque +2-->
-        <item offset="92" id="10708" /> <!--Etoile Bangles +2-->
-        <item offset="93" id="10728" /> <!--Etoile Tights +2-->
-        <item offset="94" id="10748" /> <!--Etoile Toe Shoes +2-->
-        <item offset="95" id="10669" /> <!--Argute M.board +2-->
-        <item offset="96" id="10689" /> <!--Argute Gown +2-->
-        <item offset="97" id="10709" /> <!--Argute Bracers +2-->
-        <item offset="98" id="10729" /> <!--Argute Pants +2-->
-        <item offset="99" id="10749" /> <!--Argute Loafers +2-->
-    </slip>
-    <slip id="29325">
-        <item offset="0" id="10901" /> <!--Phorcys Salade-->
-        <item offset="1" id="10474" /> <!--Phorcys Korazin-->
-        <item offset="2" id="10523" /> <!--Phorcys Mitts-->
-        <item offset="3" id="10554" /> <!--Phorcys Dirs-->
-        <item offset="4" id="10620" /> <!--Phorcys Schuhs-->
-        <item offset="5" id="10906" /> <!--Thaumas Hat-->
-        <item offset="6" id="10479" /> <!--Thaumas Coat-->
-        <item offset="7" id="10528" /> <!--Thaumas Gloves-->
-        <item offset="8" id="10559" /> <!--Thaumas Kecks-->
-        <item offset="9" id="10625" /> <!--Thaumas Nails-->
-        <item offset="10" id="10911" /> <!--Nares Cap-->
-        <item offset="11" id="10484" /> <!--Nares Saio-->
-        <item offset="12" id="10533" /> <!--Nares Cuffs-->
-        <item offset="13" id="10564" /> <!--Nares Trews-->
-        <item offset="14" id="10630" /> <!--Nares Clogs-->
-        <item offset="15" id="19799" /> <!--Herja's Fork-->
-        <item offset="16" id="18916" /> <!--Heimdall's Doom-->
-        <item offset="17" id="10442" /> <!--Laeradr Helm-->
-        <item offset="18" id="10280" /> <!--Laeradr Breastplate-->
-        <item offset="19" id="16084" /> <!--Ares' Mask-->
-        <item offset="20" id="27788" /> <!--Ares' Cuirass +1-->
-        <item offset="21" id="27928" /> <!--Ares' Gauntlets +1-->
-        <item offset="22" id="28071" /> <!--Ares' Flanchard +1-->
-        <item offset="23" id="28208" /> <!--Ares' Sollerets +1-->
-        <item offset="24" id="27649" /> <!--Skadi's Visor +1-->
-        <item offset="25" id="27789" /> <!--Skadi's Cuirie +1-->
-        <item offset="26" id="27929" /> <!--Skd. Bazubands +1-->
-        <item offset="27" id="28072" /> <!--Skd. Chausses +1-->
-        <item offset="28" id="28209" /> <!--Skd. Jambeaux +1-->
-        <item offset="29" id="27650" /> <!--Usk. Somen +1-->
-        <item offset="30" id="27790" /> <!--Usk. Haramaki +1-->
-        <item offset="31" id="27930" /> <!--Usk. Gote +1-->
-        <item offset="32" id="28073" /> <!--Usk. Hizayoroi +1-->
-        <item offset="33" id="28210" /> <!--Usk. Sune-Ate +1-->
-        <item offset="34" id="27651" /> <!--Marduk's Tiara +1-->
-        <item offset="35" id="27791" /> <!--Marduk's Jubbah +1-->
-        <item offset="36" id="27931" /> <!--Mdk. Dastanas +1-->
-        <item offset="37" id="28074" /> <!--Mdk. Shalwar +1-->
-        <item offset="38" id="28211" /> <!--Mdk. Crackows +1-->
-        <item offset="39" id="27652" /> <!--Mor. Coronal +1-->
-        <item offset="40" id="27792" /> <!--Morrigan's Robe +1-->
-        <item offset="41" id="27932" /> <!--Morrigan's Cuffs +1-->
-        <item offset="42" id="28075" /> <!--Morrigan's Slops +1-->
-        <item offset="43" id="28212" /> <!--Morrigan's Pgch. +1-->
-        <item offset="44" id="27653" /> <!--Ker's Mask-->
-        <item offset="45" id="27793" /> <!--Ker's Cuirass-->
-        <item offset="46" id="27933" /> <!--Ker's Gauntlets-->
-        <item offset="47" id="28076" /> <!--Ker's Flanchard-->
-        <item offset="48" id="28213" /> <!--Ker's Sollerets-->
-        <item offset="49" id="27654" /> <!--Sigyn's Visor-->
-        <item offset="50" id="27794" /> <!--Sigyn's Cuirie-->
-        <item offset="51" id="27934" /> <!--Sigyn's Bazubands-->
-        <item offset="52" id="28077" /> <!--Sigyn's Chausses-->
-        <item offset="53" id="28214" /> <!--Sigyn's Jambeaux-->
-        <item offset="54" id="27655" /> <!--Omodaka Somen-->
-        <item offset="55" id="27795" /> <!--Omodaka Haramaki-->
-        <item offset="56" id="27935" /> <!--Omodaka Gote-->
-        <item offset="57" id="28078" /> <!--Omo. Hizayoroi-->
-        <item offset="58" id="28215" /> <!--Omo. Sune-Ate-->
-        <item offset="59" id="27656" /> <!--Nabu's Tiara-->
-        <item offset="60" id="27796" /> <!--Nabu's Jubbah-->
-        <item offset="61" id="27936" /> <!--Nabu's Dastanas-->
-        <item offset="62" id="28079" /> <!--Nabu's Shalwar-->
-        <item offset="63" id="28216" /> <!--Nabu's Crackows-->
-        <item offset="64" id="27657" /> <!--Fea's Coronal-->
-        <item offset="65" id="27797" /> <!--Fea's Robe-->
-        <item offset="66" id="27937" /> <!--Fea's Cuffs-->
-        <item offset="67" id="28080" /> <!--Fea's Slops-->
-        <item offset="68" id="28217" /> <!--Fea's Pigaches-->
-        <item offset="69" id="27658" /> <!--Ate's Mask-->
-        <item offset="70" id="27798" /> <!--Ate's Cuirass-->
-        <item offset="71" id="27938" /> <!--Ate's Gauntlets-->
-        <item offset="72" id="28081" /> <!--Ate's Flanchard-->
-        <item offset="73" id="28218" /> <!--Ate's Sollerets-->
-        <item offset="74" id="27659" /> <!--Idi's Mask-->
-        <item offset="75" id="27799" /> <!--Idi's Jerkin-->
-        <item offset="76" id="27939" /> <!--Idi's Gloves-->
-        <item offset="77" id="28082" /> <!--Idi's Trousers-->
-        <item offset="78" id="28219" /> <!--Idi's Ledelsens-->
-        <item offset="79" id="27660" /> <!--Genta Kabuto-->
-        <item offset="80" id="27800" /> <!--Genta Hara-Ate-->
-        <item offset="81" id="27940" /> <!--Genta Gote-->
-        <item offset="82" id="28083" /> <!--Genta-no-Hakama-->
-        <item offset="83" id="28220" /> <!--Genta Sune-Ate-->
-        <item offset="84" id="27661" /> <!--Namru's Tiara-->
-        <item offset="85" id="27801" /> <!--Namru's Jubbah-->
-        <item offset="86" id="27941" /> <!--Namru's Dastanas-->
-        <item offset="87" id="28084" /> <!--Namru's Shalwar-->
-        <item offset="88" id="28221" /> <!--Namru's Crackows-->
-        <item offset="89" id="27662" /> <!--Neit's Crown-->
-        <item offset="90" id="27802" /> <!--Neit's Coat-->
-        <item offset="91" id="27942" /> <!--Neit's Cuffs-->
-        <item offset="92" id="28085" /> <!--Neit's Slops-->
-        <item offset="93" id="28222" /> <!--Neit's Pigaches-->
-        <item offset="94" id="21510" /> <!--Voluspa Knuckles-->
-        <item offset="95" id="21566" /> <!--Voluspa Knife-->
-        <item offset="96" id="21622" /> <!--Voluspa Sword-->
-        <item offset="97" id="21665" /> <!--Voluspa Blade-->
-        <item offset="98" id="21712" /> <!--Voluspa Axe-->
-        <item offset="99" id="21769" /> <!--Voluspa Chopper-->
-        <item offset="100" id="21822" /> <!--Voluspa Scythe-->
-        <item offset="101" id="21864" /> <!--Voluspa Lance-->
-        <item offset="102" id="21912" /> <!--Voluspa Katana-->
-        <item offset="103" id="21976" /> <!--Voluspa Tachi-->
-        <item offset="104" id="22006" /> <!--Voluspa Hammer-->
-        <item offset="105" id="22088" /> <!--Voluspa Pole-->
-        <item offset="106" id="22133" /> <!--Voluspa Bow-->
-        <item offset="107" id="22144" /> <!--Voluspa Gun-->
-        <item offset="108" id="22219" /> <!--Voluspa Grip-->
-        <item offset="109" id="26413" /> <!--Voluspa Shield-->
-        <item offset="110" id="23738" /> <!--Hervor Galea-->
-        <item offset="111" id="23741" /> <!--Hervor Haubert-->
-        <item offset="112" id="23744" /> <!--Hervor Mouffles-->
-        <item offset="113" id="23747" /> <!--Hervor Brayettes-->
-        <item offset="114" id="23750" /> <!--Hervor Sollerets-->
-        <item offset="115" id="23739" /> <!--Heidrek Mask-->
-        <item offset="116" id="23742" /> <!--Heidrek Harness-->
-        <item offset="117" id="23745" /> <!--Heidrek Gloves-->
-        <item offset="118" id="23748" /> <!--Heidrek Brais-->
-        <item offset="119" id="23751" /> <!--Heidrek Boots-->
-        <item offset="120" id="23740" /> <!--Angantyr Beret-->
-        <item offset="121" id="23743" /> <!--Angantyr Robe-->
-        <item offset="122" id="23746" /> <!--Angantyr Mittens-->
-        <item offset="123" id="23749" /> <!--Angantyr Tights-->
-        <item offset="124" id="23752" /> <!--Angantyr Boots-->
-    </slip>
-    <slip id="29326">
-        <item offset="0" id="27663" /> <!--Pummeler's Mask-->
-        <item offset="1" id="27807" /> <!--Pummeler's Lorica-->
-        <item offset="2" id="27943" /> <!--Pumm. Mufflers-->
-        <item offset="3" id="28090" /> <!--Pumm. Cuisses-->
-        <item offset="4" id="28223" /> <!--Pumm. Calligae-->
-        <item offset="5" id="27664" /> <!--Anchorite's Crown-->
-        <item offset="6" id="27808" /> <!--Anchorite's Cyclas-->
-        <item offset="7" id="27944" /> <!--Anchorite's Gloves-->
-        <item offset="8" id="28091" /> <!--Anchorite's Hose-->
-        <item offset="9" id="28224" /> <!--Anch. Gaiters-->
-        <item offset="10" id="27665" /> <!--Theophany Cap-->
-        <item offset="11" id="27809" /> <!--Theo. Bliaut-->
-        <item offset="12" id="27945" /> <!--Theophany Mitts-->
-        <item offset="13" id="28092" /> <!--Theo. Pantaloons-->
-        <item offset="14" id="28225" /> <!--Theo. Duckbills-->
-        <item offset="15" id="27666" /> <!--Spae. Petasos-->
-        <item offset="16" id="27810" /> <!--Spaekona's Coat-->
-        <item offset="17" id="27946" /> <!--Spaekona's Gloves-->
-        <item offset="18" id="28093" /> <!--Spaekona's Tonban-->
-        <item offset="19" id="28226" /> <!--Spaekona's Sabots-->
-        <item offset="20" id="27667" /> <!--Atrophy Chapeau-->
-        <item offset="21" id="27811" /> <!--Atrophy Tabard-->
-        <item offset="22" id="27947" /> <!--Atrophy Gloves-->
-        <item offset="23" id="28094" /> <!--Atrophy Tights-->
-        <item offset="24" id="28227" /> <!--Atrophy Boots-->
-        <item offset="25" id="27668" /> <!--Pillager's Bonnet-->
-        <item offset="26" id="27812" /> <!--Pillager's Vest-->
-        <item offset="27" id="27948" /> <!--Pillager's Armlets-->
-        <item offset="28" id="28095" /> <!--Pillager's Culottes-->
-        <item offset="29" id="28228" /> <!--Pillager's Poulaines-->
-        <item offset="30" id="27669" /> <!--Rev. Coronet-->
-        <item offset="31" id="27813" /> <!--Reverence Surcoat-->
-        <item offset="32" id="27949" /> <!--Rev. Gauntlets-->
-        <item offset="33" id="28096" /> <!--Rev. Breeches-->
-        <item offset="34" id="28229" /> <!--Rev. Leggings-->
-        <item offset="35" id="27670" /> <!--Ignominy Burgeonet-->
-        <item offset="36" id="27814" /> <!--Ignominy Cuirass-->
-        <item offset="37" id="27950" /> <!--Igno. Gauntlets-->
-        <item offset="38" id="28097" /> <!--Ignominy Flanchard-->
-        <item offset="39" id="28230" /> <!--Igno. Sollerets-->
-        <item offset="40" id="27671" /> <!--Totemic Helm-->
-        <item offset="41" id="27815" /> <!--Totemic Jackcoat-->
-        <item offset="42" id="27951" /> <!--Totemic Gloves-->
-        <item offset="43" id="28098" /> <!--Totemic Trousers-->
-        <item offset="44" id="28231" /> <!--Totemic Gaiters-->
-        <item offset="45" id="27672" /> <!--Brioso Roundlet-->
-        <item offset="46" id="27816" /> <!--Brioso Just.-->
-        <item offset="47" id="27952" /> <!--Brioso Cuffs-->
-        <item offset="48" id="28099" /> <!--Brioso Cannions-->
-        <item offset="49" id="28232" /> <!--Brioso Slippers-->
-        <item offset="50" id="27673" /> <!--Orion Beret-->
-        <item offset="51" id="27817" /> <!--Orion Jerkin-->
-        <item offset="52" id="27953" /> <!--Orion Bracers-->
-        <item offset="53" id="28100" /> <!--Orion Braccae-->
-        <item offset="54" id="28233" /> <!--Orion Socks-->
-        <item offset="55" id="27674" /> <!--Wakido Kabuto-->
-        <item offset="56" id="27818" /> <!--Wakido Domaru-->
-        <item offset="57" id="27954" /> <!--Wakido Kote-->
-        <item offset="58" id="28101" /> <!--Wakido Haidate-->
-        <item offset="59" id="28234" /> <!--Wakido Sune-Ate-->
-        <item offset="60" id="27675" /> <!--Hachiya Hatsuburi-->
-        <item offset="61" id="27819" /> <!--Hachi. Chainmail-->
-        <item offset="62" id="27955" /> <!--Hachiya Tekko-->
-        <item offset="63" id="28102" /> <!--Hachiya Hakama-->
-        <item offset="64" id="28235" /> <!--Hachiya Kyahan-->
-        <item offset="65" id="27676" /> <!--Vishap Armet-->
-        <item offset="66" id="27820" /> <!--Vishap Mail-->
-        <item offset="67" id="27956" /> <!--Vish. Fin. Gaunt-->
-        <item offset="68" id="28103" /> <!--Vishap Brais-->
-        <item offset="69" id="28236" /> <!--Vishap Greaves-->
-        <item offset="70" id="27677" /> <!--Convoker's Horn-->
-        <item offset="71" id="27821" /> <!--Convo. Doublet-->
-        <item offset="72" id="27957" /> <!--Con. Bracers-->
-        <item offset="73" id="28104" /> <!--Convoker's Spats-->
-        <item offset="74" id="28237" /> <!--Con. Pigaches-->
-        <item offset="75" id="27678" /> <!--Assim. Keffiyeh-->
-        <item offset="76" id="27822" /> <!--Assim. Jubbah-->
-        <item offset="77" id="27958" /> <!--Assim. Bazu.-->
-        <item offset="78" id="28105" /> <!--Assim. Shalwar-->
-        <item offset="79" id="28238" /> <!--Assim. Charuqs-->
-        <item offset="80" id="27679" /> <!--Laksa. Tricorne-->
-        <item offset="81" id="27823" /> <!--Laksa. Frac-->
-        <item offset="82" id="27959" /> <!--Laksa. Gants-->
-        <item offset="83" id="28106" /> <!--Laksa. Trews-->
-        <item offset="84" id="28239" /> <!--Laksa. Bottes-->
-        <item offset="85" id="27680" /> <!--Foire Taj-->
-        <item offset="86" id="27824" /> <!--Foire Tobe-->
-        <item offset="87" id="27960" /> <!--Foire Dastanas-->
-        <item offset="88" id="28107" /> <!--Foire Churidars-->
-        <item offset="89" id="28240" /> <!--Foire Babouches-->
-        <item offset="90" id="27681" /> <!--Maxixi Tiara-->
-        <item offset="91" id="27825" /> <!--Maxixi Casaque-->
-        <item offset="92" id="27961" /> <!--Maxixi Bangles-->
-        <item offset="93" id="28108" /> <!--Maxixi Tights-->
-        <item offset="94" id="28241" /> <!--Maxixi Toe Shoes-->
-        <item offset="95" id="27682" /> <!--Maxixi Tiara-->
-        <item offset="96" id="27826" /> <!--Maxixi Casaque-->
-        <item offset="97" id="27962" /> <!--Maxixi Bangles-->
-        <item offset="98" id="28109" /> <!--Maxixi Tights-->
-        <item offset="99" id="28242" /> <!--Maxixi Toe Shoes-->
-        <item offset="100" id="27683" /> <!--Acad. Mortarboard-->
-        <item offset="101" id="27827" /> <!--Academic's Gown-->
-        <item offset="102" id="27963" /> <!--Acad. Bracers-->
-        <item offset="103" id="28110" /> <!--Academic's Pants-->
-        <item offset="104" id="28243" /> <!--Acad. Loafers-->
-    </slip>
-    <slip id="29327">
-        <item offset="0" id="27684" /> <!--Pumm. Mask +1-->
-        <item offset="1" id="27828" /> <!--Pumm. Lorica +1-->
-        <item offset="2" id="27964" /> <!--Pumm. Mufflers +1-->
-        <item offset="3" id="28111" /> <!--Pumm. Cuisses +1-->
-        <item offset="4" id="28244" /> <!--Pumm. Calligae +1-->
-        <item offset="5" id="27685" /> <!--Anchor. Crown +1-->
-        <item offset="6" id="27829" /> <!--Anch. Cyclas +1-->
-        <item offset="7" id="27965" /> <!--Anch. Gloves +1-->
-        <item offset="8" id="28112" /> <!--Anch. Hose +1-->
-        <item offset="9" id="28245" /> <!--Anch. Gaiters +1-->
-        <item offset="10" id="27686" /> <!--Theo. Cap +1-->
-        <item offset="11" id="27830" /> <!--Theo. Bliaut +1-->
-        <item offset="12" id="27966" /> <!--Theo. Mitts +1-->
-        <item offset="13" id="28113" /> <!--Theo. Pant. +1-->
-        <item offset="14" id="28246" /> <!--Theo. Duckbills +1-->
-        <item offset="15" id="27687" /> <!--Spae. Petasos +1-->
-        <item offset="16" id="27831" /> <!--Spae. Coat +1-->
-        <item offset="17" id="27967" /> <!--Spae. Gloves +1-->
-        <item offset="18" id="28114" /> <!--Spae. Tonban +1-->
-        <item offset="19" id="28247" /> <!--Spae. Sabots +1-->
-        <item offset="20" id="27688" /> <!--Atro. Chapeau +1-->
-        <item offset="21" id="27832" /> <!--Atrophy Tabard +1-->
-        <item offset="22" id="27968" /> <!--Atrophy Gloves +1-->
-        <item offset="23" id="28115" /> <!--Atrophy Tights +1-->
-        <item offset="24" id="28248" /> <!--Atrophy Boots +1-->
-        <item offset="25" id="27689" /> <!--Pill. Bonnet +1-->
-        <item offset="26" id="27833" /> <!--Pillager's Vest +1-->
-        <item offset="27" id="27969" /> <!--Pill. Armlets +1-->
-        <item offset="28" id="28116" /> <!--Pill. Culottes +1-->
-        <item offset="29" id="28249" /> <!--Pill. Poulaines +1-->
-        <item offset="30" id="27690" /> <!--Rev. Coronet +1-->
-        <item offset="31" id="27834" /> <!--Rev. Surcoat +1-->
-        <item offset="32" id="27970" /> <!--Rev. Gauntlets +1-->
-        <item offset="33" id="28117" /> <!--Rev. Breeches +1-->
-        <item offset="34" id="28250" /> <!--Rev. Leggings +1-->
-        <item offset="35" id="27691" /> <!--Igno. Burgeonet +1-->
-        <item offset="36" id="27835" /> <!--Igno. Cuirass +1-->
-        <item offset="37" id="27971" /> <!--Igno. Gauntlets +1-->
-        <item offset="38" id="28118" /> <!--Igno. Flan. +1-->
-        <item offset="39" id="28251" /> <!--Igno. Sollerets +1-->
-        <item offset="40" id="27692" /> <!--Totemic Helm +1-->
-        <item offset="41" id="27836" /> <!--Tot. Jackcoat +1-->
-        <item offset="42" id="27972" /> <!--Tot. Gloves +1-->
-        <item offset="43" id="28119" /> <!--Tot. Trousers +1-->
-        <item offset="44" id="28252" /> <!--Tot. Gaiters +1-->
-        <item offset="45" id="27693" /> <!--Brioso Roundlet +1-->
-        <item offset="46" id="27837" /> <!--Brioso Just. +1-->
-        <item offset="47" id="27973" /> <!--Brioso Cuffs +1-->
-        <item offset="48" id="28120" /> <!--Brioso Cann. +1-->
-        <item offset="49" id="28253" /> <!--Brioso Slippers +1-->
-        <item offset="50" id="27694" /> <!--Orion Beret +1-->
-        <item offset="51" id="27838" /> <!--Orion Jerkin +1-->
-        <item offset="52" id="27974" /> <!--Orion Bracers +1-->
-        <item offset="53" id="28121" /> <!--Orion Braccae +1-->
-        <item offset="54" id="28254" /> <!--Orion Socks +1-->
-        <item offset="55" id="27695" /> <!--Wakido Kabuto +1-->
-        <item offset="56" id="27839" /> <!--Wakido Domaru +1-->
-        <item offset="57" id="27975" /> <!--Wakido Kote +1-->
-        <item offset="58" id="28122" /> <!--Wakido Haidate +1-->
-        <item offset="59" id="28255" /> <!--Waki. Sune-Ate +1-->
-        <item offset="60" id="27696" /> <!--Hachi. Hatsu. +1-->
-        <item offset="61" id="27840" /> <!--Hachi. Chain. +1-->
-        <item offset="62" id="27976" /> <!--Hachiya Tekko +1-->
-        <item offset="63" id="28123" /> <!--Hachi. Hakama +1-->
-        <item offset="64" id="28256" /> <!--Hachi. Kyahan +1-->
-        <item offset="65" id="27697" /> <!--Vishap Armet +1-->
-        <item offset="66" id="27841" /> <!--Vishap Mail +1-->
-        <item offset="67" id="27977" /> <!--Vishap F. G. +1-->
-        <item offset="68" id="28124" /> <!--Vishap Brais +1-->
-        <item offset="69" id="28257" /> <!--Vishap Greaves +1-->
-        <item offset="70" id="27698" /> <!--Con. Horn +1-->
-        <item offset="71" id="27842" /> <!--Con. Doublet +1-->
-        <item offset="72" id="27978" /> <!--Con. Bracers +1-->
-        <item offset="73" id="28125" /> <!--Con. Spats +1-->
-        <item offset="74" id="28258" /> <!--Con. Pigaches +1-->
-        <item offset="75" id="27699" /> <!--Assim. Keffiyeh +1-->
-        <item offset="76" id="27843" /> <!--Assim. Jubbah +1-->
-        <item offset="77" id="27979" /> <!--Assim. Bazu. +1-->
-        <item offset="78" id="28126" /> <!--Assim. Shalwar +1-->
-        <item offset="79" id="28259" /> <!--Assim. Charuqs +1-->
-        <item offset="80" id="27700" /> <!--Laksa. Tricorne +1-->
-        <item offset="81" id="27844" /> <!--Laksa. Frac +1-->
-        <item offset="82" id="27980" /> <!--Laksa. Gants +1-->
-        <item offset="83" id="28127" /> <!--Laksa. Trews +1-->
-        <item offset="84" id="28260" /> <!--Laksa. Bottes +1-->
-        <item offset="85" id="27701" /> <!--Foire Taj +1-->
-        <item offset="86" id="27845" /> <!--Foire Tobe +1-->
-        <item offset="87" id="27981" /> <!--Foire Dastanas +1-->
-        <item offset="88" id="28128" /> <!--Foire Churidars +1-->
-        <item offset="89" id="28261" /> <!--Foire Bab. +1-->
-        <item offset="90" id="27702" /> <!--Maxixi Tiara +1-->
-        <item offset="91" id="27846" /> <!--Maxixi Casaque +1-->
-        <item offset="92" id="27982" /> <!--Maxixi Bangles +1-->
-        <item offset="93" id="28129" /> <!--Maxixi Tights +1-->
-        <item offset="94" id="28262" /> <!--Maxixi Toe Shoes +1-->
-        <item offset="95" id="27703" /> <!--Maxixi Tiara +1-->
-        <item offset="96" id="27847" /> <!--Maxixi Casaque +1-->
-        <item offset="97" id="27983" /> <!--Maxixi Bangles +1-->
-        <item offset="98" id="28130" /> <!--Maxixi Tights +1-->
-        <item offset="99" id="28263" /> <!--Maxixi Toe Shoes +1-->
-        <item offset="100" id="27704" /> <!--Acad. Mortar. +1-->
-        <item offset="101" id="27848" /> <!--Acad. Gown +1-->
-        <item offset="102" id="27984" /> <!--Acad. Bracers +1-->
-        <item offset="103" id="28131" /> <!--Acad. Pants +1-->
-        <item offset="104" id="28264" /> <!--Acad. Loafers +1-->
-        <item offset="105" id="27705" /> <!--Geo. Galero +1-->
-        <item offset="106" id="27849" /> <!--Geo. Tunic +1-->
-        <item offset="107" id="27985" /> <!--Geo. Mitaines +1-->
-        <item offset="108" id="28132" /> <!--Geo. Pants +1-->
-        <item offset="109" id="28265" /> <!--Geo. Sandals +1-->
-        <item offset="110" id="27706" /> <!--Rune. Bandeau +1-->
-        <item offset="111" id="27850" /> <!--Runeist Coat +1-->
-        <item offset="112" id="27986" /> <!--Runeist Mitons +1-->
-        <item offset="113" id="28133" /> <!--Rune. Trousers +1-->
-        <item offset="114" id="28266" /> <!--Runeist Bottes +1-->
-    </slip>
-    <slip id="29328">
-        <item offset="0" id="26624" /> <!--Agoge Mask-->
-        <item offset="1" id="26800" /> <!--Agoge Lorica-->
-        <item offset="2" id="26976" /> <!--Agoge Mufflers-->
-        <item offset="3" id="27152" /> <!--Agoge Cuisses-->
-        <item offset="4" id="27328" /> <!--Agoge Calligae-->
-        <item offset="5" id="26626" /> <!--Hes. Crown-->
-        <item offset="6" id="26802" /> <!--Hes. Cyclas-->
-        <item offset="7" id="26978" /> <!--Hes. Gloves-->
-        <item offset="8" id="27154" /> <!--Hes. Hose-->
-        <item offset="9" id="27330" /> <!--Hes. Gaiters-->
-        <item offset="10" id="26628" /> <!--Piety Cap-->
-        <item offset="11" id="26804" /> <!--Piety Bliaut-->
-        <item offset="12" id="26980" /> <!--Piety Mitts-->
-        <item offset="13" id="27156" /> <!--Piety Pantaloons-->
-        <item offset="14" id="27332" /> <!--Piety Duckbills-->
-        <item offset="15" id="26630" /> <!--Arch. Petasos-->
-        <item offset="16" id="26806" /> <!--Arch. Coat-->
-        <item offset="17" id="26982" /> <!--Arch. Gloves-->
-        <item offset="18" id="27158" /> <!--Arch. Tonban-->
-        <item offset="19" id="27334" /> <!--Arch. Sabots-->
-        <item offset="20" id="26632" /> <!--Vitiation Chapeau-->
-        <item offset="21" id="26808" /> <!--Vitiation Tabard-->
-        <item offset="22" id="26984" /> <!--Vitiation Gloves-->
-        <item offset="23" id="27160" /> <!--Vitiation Tights-->
-        <item offset="24" id="27336" /> <!--Vitiation Boots-->
-        <item offset="25" id="26634" /> <!--Plun. Bonnet-->
-        <item offset="26" id="26810" /> <!--Plunderer's Vest-->
-        <item offset="27" id="26986" /> <!--Plun. Armlets-->
-        <item offset="28" id="27162" /> <!--Plun. Culottes-->
-        <item offset="29" id="27338" /> <!--Plun. Poulaines-->
-        <item offset="30" id="26636" /> <!--Cab. Coronet-->
-        <item offset="31" id="26812" /> <!--Cab. Surcoat-->
-        <item offset="32" id="26988" /> <!--Cab. Gauntlets-->
-        <item offset="33" id="27164" /> <!--Cab. Breeches-->
-        <item offset="34" id="27340" /> <!--Cab. Leggings-->
-        <item offset="35" id="26638" /> <!--Fallen's Burgeonet-->
-        <item offset="36" id="26814" /> <!--Fallen's Cuirass-->
-        <item offset="37" id="26990" /> <!--Fall. Fin. Gaunt.-->
-        <item offset="38" id="27166" /> <!--Fallen's Flanchard-->
-        <item offset="39" id="27342" /> <!--Fallen's Sollerets-->
-        <item offset="40" id="26640" /> <!--Ankusa Helm-->
-        <item offset="41" id="26816" /> <!--Ankusa Jackcoat-->
-        <item offset="42" id="26992" /> <!--Ankusa Gloves-->
-        <item offset="43" id="27168" /> <!--Ankusa Trousers-->
-        <item offset="44" id="27344" /> <!--Ankusa Gaiters-->
-        <item offset="45" id="26642" /> <!--Bihu Roundlet-->
-        <item offset="46" id="26818" /> <!--Bihu Justaucorps-->
-        <item offset="47" id="26994" /> <!--Bihu Cuffs-->
-        <item offset="48" id="27170" /> <!--Bihu Cannions-->
-        <item offset="49" id="27346" /> <!--Bihu Slippers-->
-        <item offset="50" id="26644" /> <!--Arcadian Beret-->
-        <item offset="51" id="26820" /> <!--Arcadian Jerkin-->
-        <item offset="52" id="26996" /> <!--Arcadian Bracers-->
-        <item offset="53" id="27172" /> <!--Arcadian Braccae-->
-        <item offset="54" id="27348" /> <!--Arcadian Socks-->
-        <item offset="55" id="26646" /> <!--Sakonji Kabuto-->
-        <item offset="56" id="26822" /> <!--Sakonji Domaru-->
-        <item offset="57" id="26998" /> <!--Sakonji Kote-->
-        <item offset="58" id="27174" /> <!--Sakonji Haidate-->
-        <item offset="59" id="27350" /> <!--Sakonji Sune-Ate-->
-        <item offset="60" id="26648" /> <!--Mochi. Hatsuburi-->
-        <item offset="61" id="26824" /> <!--Mochi. Chainmail-->
-        <item offset="62" id="27000" /> <!--Mochizuki Tekko-->
-        <item offset="63" id="27176" /> <!--Mochizuki Hakama-->
-        <item offset="64" id="27352" /> <!--Mochizuki Kyahan-->
-        <item offset="65" id="26650" /> <!--Ptero. Armet-->
-        <item offset="66" id="26826" /> <!--Pteroslaver Mail-->
-        <item offset="67" id="27002" /> <!--Ptero. Fin. Gaunt.-->
-        <item offset="68" id="27178" /> <!--Pteroslaver Brais-->
-        <item offset="69" id="27354" /> <!--Ptero. Greaves-->
-        <item offset="70" id="26652" /> <!--Glyphic Horn-->
-        <item offset="71" id="26828" /> <!--Glyphic Doublet-->
-        <item offset="72" id="27004" /> <!--Glyphic Bracers-->
-        <item offset="73" id="27180" /> <!--Glyphic Spats-->
-        <item offset="74" id="27356" /> <!--Glyphic Pigaches-->
-        <item offset="75" id="26654" /> <!--Luhlaza Keffiyeh-->
-        <item offset="76" id="26830" /> <!--Luhlaza Jubbah-->
-        <item offset="77" id="27006" /> <!--Luhlaza Bazubands-->
-        <item offset="78" id="27182" /> <!--Luhlaza Shalwar-->
-        <item offset="79" id="27358" /> <!--Luhlaza Charuqs-->
-        <item offset="80" id="26656" /> <!--Lanun Tricorne-->
-        <item offset="81" id="26832" /> <!--Lanun Frac-->
-        <item offset="82" id="27008" /> <!--Lanun Gants-->
-        <item offset="83" id="27184" /> <!--Lanun Trews-->
-        <item offset="84" id="27360" /> <!--Lanun Bottes-->
-        <item offset="85" id="26658" /> <!--Pitre Taj-->
-        <item offset="86" id="26834" /> <!--Pitre Tobe-->
-        <item offset="87" id="27010" /> <!--Pitre Dastanas-->
-        <item offset="88" id="27186" /> <!--Pitre Churidars-->
-        <item offset="89" id="27362" /> <!--Pitre Babouches-->
-        <item offset="90" id="26660" /> <!--Horos Tiara-->
-        <item offset="91" id="26836" /> <!--Horos Casaque-->
-        <item offset="92" id="27012" /> <!--Horos Bangles-->
-        <item offset="93" id="27188" /> <!--Horos Tights-->
-        <item offset="94" id="27364" /> <!--Horos Toe Shoes-->
-        <item offset="95" id="26662" /> <!--Peda. M.Board-->
-        <item offset="96" id="26838" /> <!--Pedagogy Gown-->
-        <item offset="97" id="27014" /> <!--Peda. Bracers-->
-        <item offset="98" id="27190" /> <!--Pedagogy Pants-->
-        <item offset="99" id="27366" /> <!--Peda. Loafers-->
-        <item offset="100" id="26664" /> <!--Bagua Galero-->
-        <item offset="101" id="26840" /> <!--Bagua Tunic-->
-        <item offset="102" id="27016" /> <!--Bagua Mitaines-->
-        <item offset="103" id="27192" /> <!--Bagua Pants-->
-        <item offset="104" id="27368" /> <!--Bagua Sandals-->
-        <item offset="105" id="26666" /> <!--Futhark Bandeau-->
-        <item offset="106" id="26842" /> <!--Futhark Coat-->
-        <item offset="107" id="27018" /> <!--Futhark Mitons-->
-        <item offset="108" id="27194" /> <!--Futhark Trousers-->
-        <item offset="109" id="27370" /> <!--Futhark Boots-->
-    </slip>
-    <slip id="29329">
-        <item offset="0" id="26625" /> <!--Agoge Mask +1-->
-        <item offset="1" id="26801" /> <!--Agoge Lorica +1-->
-        <item offset="2" id="26977" /> <!--Agoge Mufflers +1-->
-        <item offset="3" id="27153" /> <!--Agoge Cuisses +1-->
-        <item offset="4" id="27329" /> <!--Agoge Calligae +1-->
-        <item offset="5" id="26627" /> <!--Hes. Crown +1-->
-        <item offset="6" id="26803" /> <!--Hes. Cyclas +1-->
-        <item offset="7" id="26979" /> <!--Hes. Gloves +1-->
-        <item offset="8" id="27155" /> <!--Hes. Hose +1-->
-        <item offset="9" id="27331" /> <!--Hes. Gaiters +1-->
-        <item offset="10" id="26629" /> <!--Piety Cap +1-->
-        <item offset="11" id="26805" /> <!--Piety Bliaut +1-->
-        <item offset="12" id="26981" /> <!--Piety Mitts +1-->
-        <item offset="13" id="27157" /> <!--Piety Pantaln. +1-->
-        <item offset="14" id="27333" /> <!--Piety Duckbills +1-->
-        <item offset="15" id="26631" /> <!--Arch. Petasos +1-->
-        <item offset="16" id="26807" /> <!--Arch. Coat +1-->
-        <item offset="17" id="26983" /> <!--Arch. Gloves +1-->
-        <item offset="18" id="27159" /> <!--Arch. Tonban +1-->
-        <item offset="19" id="27335" /> <!--Arch. Sabots +1-->
-        <item offset="20" id="26633" /> <!--Viti. Chapeau +1-->
-        <item offset="21" id="26809" /> <!--Viti. Tabard +1-->
-        <item offset="22" id="26985" /> <!--Viti. Gloves +1-->
-        <item offset="23" id="27161" /> <!--Viti. Tights +1-->
-        <item offset="24" id="27337" /> <!--Vitiation Boots +1-->
-        <item offset="25" id="26635" /> <!--Plun. Bonnet +1-->
-        <item offset="26" id="26811" /> <!--Plunderer's Vest +1-->
-        <item offset="27" id="26987" /> <!--Plun. Armlets +1-->
-        <item offset="28" id="27163" /> <!--Plun. Culottes +1-->
-        <item offset="29" id="27339" /> <!--Plun. Poulaines +1-->
-        <item offset="30" id="26637" /> <!--Cab. Coronet +1-->
-        <item offset="31" id="26813" /> <!--Cab. Surcoat +1-->
-        <item offset="32" id="26989" /> <!--Cab. Gauntlets +1-->
-        <item offset="33" id="27165" /> <!--Cab. Breeches +1-->
-        <item offset="34" id="27341" /> <!--Cab. Leggings +1-->
-        <item offset="35" id="26639" /> <!--Fall. Burgeonet +1-->
-        <item offset="36" id="26815" /> <!--Fall. Cuirass +1-->
-        <item offset="37" id="26991" /> <!--Fall. Fin. Gaunt. +1-->
-        <item offset="38" id="27167" /> <!--Fall. Flanchard +1-->
-        <item offset="39" id="27343" /> <!--Fall. Sollerets +1-->
-        <item offset="40" id="26641" /> <!--Ankusa Helm +1-->
-        <item offset="41" id="26817" /> <!--An. Jackcoat +1-->
-        <item offset="42" id="26993" /> <!--Ankusa Gloves +1-->
-        <item offset="43" id="27169" /> <!--Ankusa Trousers +1-->
-        <item offset="44" id="27345" /> <!--Ankusa Gaiters +1-->
-        <item offset="45" id="26643" /> <!--Bihu Roundlet +1-->
-        <item offset="46" id="26819" /> <!--Bihu Jstcorps +1-->
-        <item offset="47" id="26995" /> <!--Bihu Cuffs +1-->
-        <item offset="48" id="27171" /> <!--Bihu Cannions +1-->
-        <item offset="49" id="27347" /> <!--Bihu Slippers +1-->
-        <item offset="50" id="26645" /> <!--Arcadian Beret +1-->
-        <item offset="51" id="26821" /> <!--Arc. Jerkin +1-->
-        <item offset="52" id="26997" /> <!--Arc. Bracers +1-->
-        <item offset="53" id="27173" /> <!--Arc. Braccae +1-->
-        <item offset="54" id="27349" /> <!--Arcadian Socks +1-->
-        <item offset="55" id="26647" /> <!--Sakonji Kabuto +1-->
-        <item offset="56" id="26823" /> <!--Sakonji Domaru +1-->
-        <item offset="57" id="26999" /> <!--Sakonji Kote +1-->
-        <item offset="58" id="27175" /> <!--Sakonji Haidate +1-->
-        <item offset="59" id="27351" /> <!--Sak. Sune-Ate +1-->
-        <item offset="60" id="26649" /> <!--Mochi. Hatsuburi +1-->
-        <item offset="61" id="26825" /> <!--Mochi. Chainmail +1-->
-        <item offset="62" id="27001" /> <!--Mochizuki Tekko +1-->
-        <item offset="63" id="27177" /> <!--Mochi. Hakama +1-->
-        <item offset="64" id="27353" /> <!--Mochi. Kyahan +1-->
-        <item offset="65" id="26651" /> <!--Ptero. Armet +1-->
-        <item offset="66" id="26827" /> <!--Ptero. Mail +1-->
-        <item offset="67" id="27003" /> <!--Ptero. Fin. G. +1-->
-        <item offset="68" id="27179" /> <!--Ptero. Brais +1-->
-        <item offset="69" id="27355" /> <!--Ptero. Greaves +1-->
-        <item offset="70" id="26653" /> <!--Glyphic Horn +1-->
-        <item offset="71" id="26829" /> <!--Glyphic Doublet +1-->
-        <item offset="72" id="27005" /> <!--Glyphic Bracers +1-->
-        <item offset="73" id="27181" /> <!--Glyphic Spats +1-->
-        <item offset="74" id="27357" /> <!--Glyph. Pigaches +1-->
-        <item offset="75" id="26655" /> <!--Luh. Keffiyeh +1-->
-        <item offset="76" id="26831" /> <!--Luhlaza Jubbah +1-->
-        <item offset="77" id="27007" /> <!--Luh. Bazubands +1-->
-        <item offset="78" id="27183" /> <!--Luhlaza Shalwar +1-->
-        <item offset="79" id="27359" /> <!--Luhlaza Charuqs +1-->
-        <item offset="80" id="26657" /> <!--Lanun Tricorne +1-->
-        <item offset="81" id="26833" /> <!--Lanun Frac +1-->
-        <item offset="82" id="27009" /> <!--Lanun Gants +1-->
-        <item offset="83" id="27185" /> <!--Lanun Trews +1-->
-        <item offset="84" id="27361" /> <!--Lanun Bottes +1-->
-        <item offset="85" id="26659" /> <!--Pitre Taj +1-->
-        <item offset="86" id="26835" /> <!--Pitre Tobe +1-->
-        <item offset="87" id="27011" /> <!--Pitre Dastanas +1-->
-        <item offset="88" id="27187" /> <!--Pitre Churidars +1-->
-        <item offset="89" id="27363" /> <!--Pitre Babouches +1-->
-        <item offset="90" id="26661" /> <!--Horos Tiara +1-->
-        <item offset="91" id="26837" /> <!--Horos Casaque +1-->
-        <item offset="92" id="27013" /> <!--Horos Bangles +1-->
-        <item offset="93" id="27189" /> <!--Horos Tights +1-->
-        <item offset="94" id="27365" /> <!--Horos Toe Shoes +1-->
-        <item offset="95" id="26663" /> <!--Peda. M.Board +1-->
-        <item offset="96" id="26839" /> <!--Peda. Gown +1-->
-        <item offset="97" id="27015" /> <!--Peda. Bracers +1-->
-        <item offset="98" id="27191" /> <!--Peda. Pants +1-->
-        <item offset="99" id="27367" /> <!--Peda. Loafers +1-->
-        <item offset="100" id="26665" /> <!--Bagua Galero +1-->
-        <item offset="101" id="26841" /> <!--Bagua Tunic +1-->
-        <item offset="102" id="27017" /> <!--Bagua Mitaines +1-->
-        <item offset="103" id="27193" /> <!--Bagua Pants +1-->
-        <item offset="104" id="27369" /> <!--Bagua Sandals +1-->
-        <item offset="105" id="26667" /> <!--Fu. Bandeau +1-->
-        <item offset="106" id="26843" /> <!--Futhark Coat +1-->
-        <item offset="107" id="27019" /> <!--Futhark Mitons +1-->
-        <item offset="108" id="27195" /> <!--Futhark Trousers +1-->
-        <item offset="109" id="27371" /> <!--Futhark Boots +1-->
-    </slip>
-    <slip id="29330">
-        <item offset="0" id="27715" /> <!--Goblin Masque-->
-        <item offset="1" id="27866" /> <!--Goblin Suit-->
-        <item offset="2" id="27716" /> <!--G. Moogle Masque-->
-        <item offset="3" id="27867" /> <!--G. Moogle Suit-->
-        <item offset="4" id="278" /> <!--Cardian Statue-->
-        <item offset="5" id="281" /> <!--Atomos Statue-->
-        <item offset="6" id="284" /> <!--Goobbue Statue-->
-        <item offset="7" id="3680" /> <!--Judgment Day-->
-        <item offset="8" id="3681" /> <!--Alzadaal Table-->
-        <item offset="9" id="27859" /> <!--Kengyu Happi-->
-        <item offset="10" id="28149" /> <!--Ken. Hanmomohiki-->
-        <item offset="11" id="27860" /> <!--Shokujo Happi-->
-        <item offset="12" id="28150" /> <!--Sho. Hanmomohiki-->
-        <item offset="13" id="21107" /> <!--Kyuka Uchiwa-->
-        <item offset="14" id="21108" /> <!--Kyuka Uchiwa +1-->
-        <item offset="15" id="27625" /> <!--Morbol Shield-->
-        <item offset="16" id="27626" /> <!--Cassie's Shield-->
-        <item offset="17" id="26693" /> <!--Morbol Cap-->
-        <item offset="18" id="26694" /> <!--Cassie's Cap-->
-        <item offset="19" id="26707" /> <!--Flan Masque-->
-        <item offset="20" id="26708" /> <!--Flan Masque +1-->
-        <item offset="21" id="27631" /> <!--Cait Sith Guard-->
-        <item offset="22" id="27632" /> <!--Cait Sith Gua. +1-->
-        <item offset="23" id="26705" /> <!--Mandra. Masque-->
-        <item offset="24" id="26706" /> <!--Mandra. Masque +1-->
-        <item offset="25" id="27854" /> <!--Mandra. Suit-->
-        <item offset="26" id="27855" /> <!--Mandra. Suit +1-->
-        <item offset="27" id="26703" /> <!--Lyco. Masque-->
-        <item offset="28" id="26704" /> <!--Lyco. Masque +1-->
-        <item offset="29" id="3682" /> <!--Sproutling Board-->
-        <item offset="30" id="3683" /> <!--Forest. Board-->
-        <item offset="31" id="3684" /> <!--Princess Board-->
-        <item offset="32" id="3685" /> <!--Empress Board-->
-        <item offset="33" id="3686" /> <!--Duelist Board-->
-        <item offset="34" id="3687" /> <!--Crystal Board-->
-        <item offset="35" id="3688" /> <!--Dancer Board-->
-        <item offset="36" id="3689" /> <!--Wizardess Board-->
-        <item offset="37" id="3690" /> <!--Fighter Board-->
-        <item offset="38" id="3691" /> <!--Guardian Board-->
-        <item offset="39" id="3692" /> <!--Stoic Board-->
-        <item offset="40" id="3693" /> <!--Lamb Carving-->
-        <item offset="41" id="3694" /> <!--Pol. Lamb Carving-->
-        <item offset="42" id="3695" /> <!--Cait Sith Car.-->
-        <item offset="43" id="21097" /> <!--Leafkin Bopper-->
-        <item offset="44" id="21098" /> <!--Leafkin Bopper +1-->
-        <item offset="45" id="26717" /> <!--Cait Sith Cap-->
-        <item offset="46" id="26718" /> <!--Cait Sith Cap +1-->
-        <item offset="47" id="26728" /> <!--Frosty Cap-->
-        <item offset="48" id="26719" /> <!--Sheep Cap-->
-        <item offset="49" id="26720" /> <!--Sheep Cap +1-->
-        <item offset="50" id="26889" /> <!--Heart Apron-->
-        <item offset="51" id="26890" /> <!--Heart Apron +1-->
-        <item offset="52" id="21095" /> <!--Heartbeater-->
-        <item offset="53" id="21096" /> <!--Heartbeater +1-->
-        <item offset="54" id="26738" /> <!--Leafkin Cap-->
-        <item offset="55" id="26739" /> <!--Leafkin Cap +1-->
-        <item offset="56" id="26729" /> <!--Corolla-->
-        <item offset="57" id="26730" /> <!--Celeste Cap-->
-        <item offset="58" id="26788" /> <!--Rabbit Cap-->
-        <item offset="59" id="26946" /> <!--Pupil's Shirt-->
-        <item offset="60" id="27281" /> <!--Pupil's Trousers-->
-        <item offset="61" id="27455" /> <!--Pupil's Shoes-->
-        <item offset="62" id="26789" /> <!--Shobuhouou Kabuto-->
-        <item offset="63" id="3698" /> <!--Cherry Tree-->
-        <item offset="64" id="20713" /> <!--Excalipoor-->
-        <item offset="65" id="20714" /> <!--Excalipoor II-->
-        <item offset="66" id="26798" /> <!--Behemoth Masque-->
-        <item offset="67" id="26954" /> <!--Behemoth Suit-->
-        <item offset="68" id="26799" /> <!--Behe. Masque +1-->
-        <item offset="69" id="26955" /> <!--Behemoth Suit +1-->
-        <item offset="70" id="3706" /> <!--Vana'clock-->
-        <item offset="71" id="26956" /> <!--Poroggo Coat-->
-        <item offset="72" id="26957" /> <!--Poroggo Coat +1-->
-        <item offset="73" id="3705" /> <!--Far East Hearth-->
-        <item offset="74" id="26964" /> <!--Pupil's Camisa-->
-        <item offset="75" id="26965" /> <!--Ta Moko-->
-        <item offset="76" id="27291" /> <!--Swimming Togs-->
-        <item offset="77" id="26967" /> <!--Cossie Top-->
-        <item offset="78" id="27293" /> <!--Cossie Bottom-->
-        <item offset="79" id="26966" /> <!--Ta Moko +1-->
-        <item offset="80" id="27292" /> <!--Swimming Togs +1-->
-        <item offset="81" id="26968" /> <!--Cossie Top +1-->
-        <item offset="82" id="27294" /> <!--Cossie Bottom +1-->
-        <item offset="83" id="21153" /> <!--Malice Masher-->
-        <item offset="84" id="21154" /> <!--Malice Masher +1-->
-        <item offset="85" id="21086" /> <!--Heartstopper-->
-        <item offset="86" id="21087" /> <!--Heartstopper +1-->
-        <item offset="87" id="25606" /> <!--Agent Hood-->
-        <item offset="88" id="26974" /> <!--Agent Coat-->
-        <item offset="89" id="27111" /> <!--Agent Cuffs-->
-        <item offset="90" id="27296" /> <!--Agent Pants-->
-        <item offset="91" id="27467" /> <!--Agent Boots-->
-        <item offset="92" id="25607" /> <!--Starlet Flower-->
-        <item offset="93" id="26975" /> <!--Starlet Jabot-->
-        <item offset="94" id="27112" /> <!--Starlet Gloves-->
-        <item offset="95" id="27297" /> <!--Starlet Skirt-->
-        <item offset="96" id="27468" /> <!--Starlet Boots-->
-        <item offset="97" id="14195" /> <!--Waders-->
-        <item offset="98" id="14830" /> <!--Carpenter's Gloves-->
-        <item offset="99" id="14831" /> <!--Smithy's Mitts-->
-        <item offset="100" id="13945" /> <!--Shaded Specs.-->
-        <item offset="101" id="13946" /> <!--Magnifying Specs.-->
-        <item offset="102" id="14832" /> <!--Tanner's Gloves-->
-        <item offset="103" id="13947" /> <!--Protective Specs.-->
-        <item offset="104" id="17058" /> <!--Caduceus-->
-        <item offset="105" id="13948" /> <!--Chef's Hat-->
-        <item offset="106" id="14400" /> <!--Fisherman's Apron-->
-        <item offset="107" id="14392" /> <!--Carpenter's Apron-->
-        <item offset="108" id="14393" /> <!--Blacksmith's Apn.-->
-        <item offset="109" id="14394" /> <!--Goldsmith's Apron-->
-        <item offset="110" id="14395" /> <!--Weaver's Apron-->
-        <item offset="111" id="14396" /> <!--Tanner's Apron-->
-        <item offset="112" id="14397" /> <!--Boneworker's Apn.-->
-        <item offset="113" id="14398" /> <!--Alchemist's Apron-->
-        <item offset="114" id="14399" /> <!--Culinarian's Apron-->
-        <item offset="115" id="11337" /> <!--Fisherman's Smock-->
-        <item offset="116" id="11329" /> <!--Carpenter's Smock-->
-        <item offset="117" id="11330" /> <!--Blksmith. Smock-->
-        <item offset="118" id="11331" /> <!--Goldsmith's Smock-->
-        <item offset="119" id="11332" /> <!--Weaver's Smock-->
-        <item offset="120" id="11333" /> <!--Tanner's Smock-->
-        <item offset="121" id="11334" /> <!--Bonewrk. Smock-->
-        <item offset="122" id="11335" /> <!--Alchemist's Smock-->
-        <item offset="123" id="11336" /> <!--Culinarian's Smock-->
-        <item offset="124" id="15819" /> <!--Carpenter's Ring-->
-        <item offset="125" id="15820" /> <!--Smith's Ring-->
-        <item offset="126" id="15821" /> <!--Goldsmith's Ring-->
-        <item offset="127" id="15822" /> <!--Tailor's Ring-->
-        <item offset="128" id="15823" /> <!--Tanner's Ring-->
-        <item offset="129" id="15824" /> <!--Bonecrafter's Ring-->
-        <item offset="130" id="15825" /> <!--Alchemist's Ring-->
-        <item offset="131" id="15826" /> <!--Chef's Ring-->
-        <item offset="132" id="3670" /> <!--Net and Lure-->
-        <item offset="133" id="3672" /> <!--Carpenter's Kit-->
-        <item offset="134" id="3661" /> <!--Stone Hearth-->
-        <item offset="135" id="3595" /> <!--Gemscope-->
-        <item offset="136" id="3665" /> <!--Spinning Wheel-->
-        <item offset="137" id="3668" /> <!--Hide Stretcher-->
-        <item offset="138" id="3663" /> <!--Bonecraft Tools-->
-        <item offset="139" id="3674" /> <!--Alembic-->
-        <item offset="140" id="3667" /> <!--Brass Crock-->
-        <item offset="141" id="191" /> <!--Fishing Hole Map-->
-        <item offset="142" id="28" /> <!--Drawing Desk-->
-        <item offset="143" id="153" /> <!--Mastersmith Anvil-->
-        <item offset="144" id="151" /> <!--Fool's Gold-->
-        <item offset="145" id="198" /> <!--Gilt Tapestry-->
-        <item offset="146" id="202" /> <!--Golden Fleece-->
-        <item offset="147" id="142" /> <!--Drogaroga's Fang-->
-        <item offset="148" id="134" /> <!--Emeralda-->
-        <item offset="149" id="137" /> <!--Cordon Bleu Set-->
-        <item offset="150" id="340" /> <!--Fisherman's Sign-->
-        <item offset="151" id="341" /> <!--Carpenter's Sign-->
-        <item offset="152" id="334" /> <!--Blacksmith's Sign-->
-        <item offset="153" id="335" /> <!--Goldsmith's Sign-->
-        <item offset="154" id="337" /> <!--Weaver's Sign-->
-        <item offset="155" id="339" /> <!--Tanner's Sign-->
-        <item offset="156" id="336" /> <!--Boneworker's Sign-->
-        <item offset="157" id="342" /> <!--Alchemist's Sign-->
-        <item offset="158" id="338" /> <!--Culinarian's Sign-->
-        <item offset="159" id="3631" /> <!--Fishermn. Stall-->
-        <item offset="160" id="3632" /> <!--Carpntr. Stall-->
-        <item offset="161" id="3625" /> <!--Blksmth. Stall-->
-        <item offset="162" id="3626" /> <!--Gldsmth. Stall-->
-        <item offset="163" id="3628" /> <!--Weavers' Stall-->
-        <item offset="164" id="3630" /> <!--Tanners' Stall-->
-        <item offset="165" id="3627" /> <!--Bonewrk. Stall-->
-        <item offset="166" id="3633" /> <!--Alchmsts. Stall-->
-        <item offset="167" id="3629" /> <!--Culinary Stall-->
-        <item offset="168" id="25632" /> <!--Carbie Cap-->
-        <item offset="169" id="25633" /> <!--Carbie Cap +1-->
-        <item offset="170" id="25604" /> <!--Buffalo Cap-->
-        <item offset="171" id="25713" /> <!--Track Shirt-->
-        <item offset="172" id="27325" /> <!--Track Pants-->
-        <item offset="173" id="25714" /> <!--Track Shirt +1-->
-        <item offset="174" id="27326" /> <!--Track Pants +1-->
-        <item offset="175" id="3651" /> <!--Harvest Pastry-->
-        <item offset="176" id="25711" /> <!--Botulus Suit-->
-        <item offset="177" id="25712" /> <!--Botulus Suit +1-->
-        <item offset="178" id="10925" /> <!--Fisher's Torque-->
-        <item offset="179" id="10948" /> <!--Carver's Torque-->
-        <item offset="180" id="10949" /> <!--Smithy's Torque-->
-        <item offset="181" id="10950" /> <!--Goldsm. Torque-->
-        <item offset="182" id="10951" /> <!--Weaver's Torque-->
-        <item offset="183" id="10952" /> <!--Tanner's Torque-->
-        <item offset="184" id="10953" /> <!--Bone. Torque-->
-        <item offset="185" id="10954" /> <!--Alchemst. Torque-->
-        <item offset="186" id="10955" /> <!--Culin. Torque-->
-        <item offset="187" id="25657" /> <!--Wyrmking Masque-->
-        <item offset="188" id="25756" /> <!--Wyrmking Suit-->
-        <item offset="189" id="25658" /> <!--Wyrm. Masque +1-->
-        <item offset="190" id="25757" /> <!--Wyrmking Suit +1-->
-        <item offset="191" id="25909" /> <!--Morbol Subligar-->
-    </slip>
-    <slip id="29331">
-        <item offset="0" id="26740" /> <!--Boii Mask-->
-        <item offset="1" id="26898" /> <!--Boii Lorica-->
-        <item offset="2" id="27052" /> <!--Boii Mufflers-->
-        <item offset="3" id="27237" /> <!--Boii Cuisses-->
-        <item offset="4" id="27411" /> <!--Boii Calligae-->
-        <item offset="5" id="26742" /> <!--Bhikku Crown-->
-        <item offset="6" id="26900" /> <!--Bhikku Cyclas-->
-        <item offset="7" id="27054" /> <!--Bhikku Gloves-->
-        <item offset="8" id="27239" /> <!--Bhikku Hose-->
-        <item offset="9" id="27413" /> <!--Bhikku Gaiters-->
-        <item offset="10" id="26744" /> <!--Ebers Cap-->
-        <item offset="11" id="26902" /> <!--Ebers Bliaut-->
-        <item offset="12" id="27056" /> <!--Ebers Mitts-->
-        <item offset="13" id="27241" /> <!--Ebers Pantaloons-->
-        <item offset="14" id="27415" /> <!--Ebers Duckbills-->
-        <item offset="15" id="26746" /> <!--Wicce Petasos-->
-        <item offset="16" id="26904" /> <!--Wicce Coat-->
-        <item offset="17" id="27058" /> <!--Wicce Gloves-->
-        <item offset="18" id="27243" /> <!--Wicce Chausses-->
-        <item offset="19" id="27417" /> <!--Wicce Sabots-->
-        <item offset="20" id="26748" /> <!--Lethargy Chappel-->
-        <item offset="21" id="26906" /> <!--Lethargy Sayon-->
-        <item offset="22" id="27060" /> <!--Leth. Gantherots-->
-        <item offset="23" id="27245" /> <!--Leth. Fuseau-->
-        <item offset="24" id="27419" /> <!--Leth. Houseaux-->
-        <item offset="25" id="26750" /> <!--Skulker's Bonnet-->
-        <item offset="26" id="26908" /> <!--Skulker's Vest-->
-        <item offset="27" id="27062" /> <!--Skulker's Armlets-->
-        <item offset="28" id="27247" /> <!--Skulker's Culottes-->
-        <item offset="29" id="27421" /> <!--Skulk. Poulaines-->
-        <item offset="30" id="26752" /> <!--Chevalier's Armet-->
-        <item offset="31" id="26910" /> <!--Chev. Cuirass-->
-        <item offset="32" id="27064" /> <!--Chev. Gauntlets-->
-        <item offset="33" id="27249" /> <!--Chevalier's Cuisses-->
-        <item offset="34" id="27423" /> <!--Chev. Sabatons-->
-        <item offset="35" id="26754" /> <!--Heathen's Burgeonet-->
-        <item offset="36" id="26912" /> <!--Heathen's Cuirass-->
-        <item offset="37" id="27066" /> <!--Heath. Gauntlets-->
-        <item offset="38" id="27251" /> <!--Heath. Flanchard-->
-        <item offset="39" id="27425" /> <!--Heath. Sollerets-->
-        <item offset="40" id="26756" /> <!--Nukumi Cabasset-->
-        <item offset="41" id="26914" /> <!--Nukumi Gausape-->
-        <item offset="42" id="27068" /> <!--Nukumi Manoplas-->
-        <item offset="43" id="27253" /> <!--Nukumi Quijotes-->
-        <item offset="44" id="27427" /> <!--Nukumi Ocreae-->
-        <item offset="45" id="26758" /> <!--Fili Calot-->
-        <item offset="46" id="26916" /> <!--Fili Hongreline-->
-        <item offset="47" id="27070" /> <!--Fili Manchettes-->
-        <item offset="48" id="27255" /> <!--Fili Rhingrave-->
-        <item offset="49" id="27429" /> <!--Fili Cothurnes-->
-        <item offset="50" id="26760" /> <!--Amini Gapette-->
-        <item offset="51" id="26918" /> <!--Amini Caban-->
-        <item offset="52" id="27072" /> <!--Amini Glovelettes-->
-        <item offset="53" id="27257" /> <!--Amini Bragues-->
-        <item offset="54" id="27431" /> <!--Amini Bottillons-->
-        <item offset="55" id="26762" /> <!--Kasuga Kabuto-->
-        <item offset="56" id="26920" /> <!--Kasuga Domaru-->
-        <item offset="57" id="27074" /> <!--Kasuga Kote-->
-        <item offset="58" id="27259" /> <!--Kasuga Haidate-->
-        <item offset="59" id="27433" /> <!--Kasuga Sune-Ate-->
-        <item offset="60" id="26764" /> <!--Hattori Zukin-->
-        <item offset="61" id="26922" /> <!--Hattori Ningi-->
-        <item offset="62" id="27076" /> <!--Hattori Tekko-->
-        <item offset="63" id="27261" /> <!--Hattori Hakama-->
-        <item offset="64" id="27435" /> <!--Hattori Kyahan-->
-        <item offset="65" id="26766" /> <!--Peltast's Mezail-->
-        <item offset="66" id="26924" /> <!--Peltast's Plackart-->
-        <item offset="67" id="27078" /> <!--Pel. Vambraces-->
-        <item offset="68" id="27263" /> <!--Peltast's Cuissots-->
-        <item offset="69" id="27437" /> <!--Pelt. Schynbalds-->
-        <item offset="70" id="26768" /> <!--Beckoner's Horn-->
-        <item offset="71" id="26926" /> <!--Beckoner's Doublet-->
-        <item offset="72" id="27080" /> <!--Beckoner's Bracers-->
-        <item offset="73" id="27265" /> <!--Beckoner's Spats-->
-        <item offset="74" id="27439" /> <!--Beck. Pigaches-->
-        <item offset="75" id="26770" /> <!--Hashishin Kavuk-->
-        <item offset="76" id="26928" /> <!--Hashishin Mintan-->
-        <item offset="77" id="27082" /> <!--Hashi. Bazubands-->
-        <item offset="78" id="27267" /> <!--Hashishin Tayt-->
-        <item offset="79" id="27441" /> <!--Hashishin Basmak-->
-        <item offset="80" id="26772" /> <!--Chass. Tricorne-->
-        <item offset="81" id="26930" /> <!--Chasseur's Frac-->
-        <item offset="82" id="27084" /> <!--Chasseur's Gants-->
-        <item offset="83" id="27269" /> <!--Chas. Culottes-->
-        <item offset="84" id="27443" /> <!--Chasseur's Bottes-->
-        <item offset="85" id="26774" /> <!--Karagoz Cappello-->
-        <item offset="86" id="26932" /> <!--Karagoz Farsetto-->
-        <item offset="87" id="27086" /> <!--Karagoz Guanti-->
-        <item offset="88" id="27271" /> <!--Karagoz Pantaloni-->
-        <item offset="89" id="27445" /> <!--Karagoz Scarpe-->
-        <item offset="90" id="26776" /> <!--Maculele Tiara-->
-        <item offset="91" id="26934" /> <!--Maculele Casaque-->
-        <item offset="92" id="27088" /> <!--Maculele Bangles-->
-        <item offset="93" id="27273" /> <!--Maculele Tights-->
-        <item offset="94" id="27447" /> <!--Macu. Toe Shoes-->
-        <item offset="95" id="26778" /> <!--Arbatel Bonnet-->
-        <item offset="96" id="26936" /> <!--Arbatel Gown-->
-        <item offset="97" id="27090" /> <!--Arbatel Bracers-->
-        <item offset="98" id="27275" /> <!--Arbatel Pants-->
-        <item offset="99" id="27449" /> <!--Arbatel Loafers-->
-        <item offset="100" id="26780" /> <!--Azimuth Hood-->
-        <item offset="101" id="26938" /> <!--Azimuth Coat-->
-        <item offset="102" id="27092" /> <!--Azimuth Gloves-->
-        <item offset="103" id="27277" /> <!--Azimuth Tights-->
-        <item offset="104" id="27451" /> <!--Azimuth Gaiters-->
-        <item offset="105" id="26782" /> <!--Erilaz Galea-->
-        <item offset="106" id="26940" /> <!--Erilaz Surcoat-->
-        <item offset="107" id="27094" /> <!--Erilaz Gauntlets-->
-        <item offset="108" id="27279" /> <!--Erilaz Leg Guards-->
-        <item offset="109" id="27453" /> <!--Erilaz Greaves-->
-    </slip>
-    <slip id="29332">
-        <item offset="0" id="26741" /> <!--Boii Mask +1-->
-        <item offset="1" id="26899" /> <!--Boii Lorica +1-->
-        <item offset="2" id="27053" /> <!--Boii Mufflers +1-->
-        <item offset="3" id="27238" /> <!--Boii Cuisses +1-->
-        <item offset="4" id="27412" /> <!--Boii Calligae +1-->
-        <item offset="5" id="26743" /> <!--Bhikku Crown +1-->
-        <item offset="6" id="26901" /> <!--Bhikku Cyclas +1-->
-        <item offset="7" id="27055" /> <!--Bhikku Gloves +1-->
-        <item offset="8" id="27240" /> <!--Bhikku Hose +1-->
-        <item offset="9" id="27414" /> <!--Bhikku Gaiters +1-->
-        <item offset="10" id="26745" /> <!--Ebers Cap +1-->
-        <item offset="11" id="26903" /> <!--Ebers Bliaut +1-->
-        <item offset="12" id="27057" /> <!--Ebers Mitts +1-->
-        <item offset="13" id="27242" /> <!--Ebers Pant. +1-->
-        <item offset="14" id="27416" /> <!--Ebers Duckbills +1-->
-        <item offset="15" id="26747" /> <!--Wicce Petasos +1-->
-        <item offset="16" id="26905" /> <!--Wicce Coat +1-->
-        <item offset="17" id="27059" /> <!--Wicce Gloves +1-->
-        <item offset="18" id="27244" /> <!--Wicce Chausses +1-->
-        <item offset="19" id="27418" /> <!--Wicce Sabots +1-->
-        <item offset="20" id="26749" /> <!--Leth. Chappel +1-->
-        <item offset="21" id="26907" /> <!--Lethargy Sayon +1-->
-        <item offset="22" id="27061" /> <!--Leth. Gantherots +1-->
-        <item offset="23" id="27246" /> <!--Leth. Fuseau +1-->
-        <item offset="24" id="27420" /> <!--Leth. Houseaux +1-->
-        <item offset="25" id="26751" /> <!--Skulker's Bonnet +1-->
-        <item offset="26" id="26909" /> <!--Skulker's Vest +1-->
-        <item offset="27" id="27063" /> <!--Skulk. Armlets +1-->
-        <item offset="28" id="27248" /> <!--Skulk. Culottes +1-->
-        <item offset="29" id="27422" /> <!--Skulk. Poulaines +1-->
-        <item offset="30" id="26753" /> <!--Chev. Armet +1-->
-        <item offset="31" id="26911" /> <!--Chev. Cuirass +1-->
-        <item offset="32" id="27065" /> <!--Chev. Gauntlets +1-->
-        <item offset="33" id="27250" /> <!--Chev. Cuisses +1-->
-        <item offset="34" id="27424" /> <!--Chev. Sabatons +1-->
-        <item offset="35" id="26755" /> <!--Heath. Burgeonet +1-->
-        <item offset="36" id="26913" /> <!--Heath. Cuirass +1-->
-        <item offset="37" id="27067" /> <!--Heath. Gauntlets +1-->
-        <item offset="38" id="27252" /> <!--Heath. Flanchard +1-->
-        <item offset="39" id="27426" /> <!--Heath. Sollerets +1-->
-        <item offset="40" id="26757" /> <!--Nuk. Cabasset +1-->
-        <item offset="41" id="26915" /> <!--Nukumi Gausape +1-->
-        <item offset="42" id="27069" /> <!--Nukumi Manoplas +1-->
-        <item offset="43" id="27254" /> <!--Nukumi Quijotes +1-->
-        <item offset="44" id="27428" /> <!--Nukumi Ocreae +1-->
-        <item offset="45" id="26759" /> <!--Fili Calot +1-->
-        <item offset="46" id="26917" /> <!--Fili Hongreline +1-->
-        <item offset="47" id="27071" /> <!--Fili Manchettes +1-->
-        <item offset="48" id="27256" /> <!--Fili Rhingrave +1-->
-        <item offset="49" id="27430" /> <!--Fili Cothurnes +1-->
-        <item offset="50" id="26761" /> <!--Amini Gapette +1-->
-        <item offset="51" id="26919" /> <!--Amini Caban +1-->
-        <item offset="52" id="27073" /> <!--Amini Glove. +1-->
-        <item offset="53" id="27258" /> <!--Amini Bragues +1-->
-        <item offset="54" id="27432" /> <!--Amini Bottillons +1-->
-        <item offset="55" id="26763" /> <!--Kasuga Kabuto +1-->
-        <item offset="56" id="26921" /> <!--Kasuga Domaru +1-->
-        <item offset="57" id="27075" /> <!--Kasuga Kote +1-->
-        <item offset="58" id="27260" /> <!--Kasuga Haidate +1-->
-        <item offset="59" id="27434" /> <!--Kas. Sune-Ate +1-->
-        <item offset="60" id="26765" /> <!--Hattori Zukin +1-->
-        <item offset="61" id="26923" /> <!--Hattori Ningi +1-->
-        <item offset="62" id="27077" /> <!--Hattori Tekko +1-->
-        <item offset="63" id="27262" /> <!--Hattori Hakama +1-->
-        <item offset="64" id="27436" /> <!--Hattori Kyahan +1-->
-        <item offset="65" id="26767" /> <!--Peltast's Mezail +1-->
-        <item offset="66" id="26925" /> <!--Pelt. Plackart +1-->
-        <item offset="67" id="27079" /> <!--Pel. Vambraces +1-->
-        <item offset="68" id="27264" /> <!--Pelt. Cuissots +1-->
-        <item offset="69" id="27438" /> <!--Pelt. Schyn. +1-->
-        <item offset="70" id="26769" /> <!--Beckoner's Horn +1-->
-        <item offset="71" id="26927" /> <!--Beck. Doublet +1-->
-        <item offset="72" id="27081" /> <!--Beck. Bracers +1-->
-        <item offset="73" id="27266" /> <!--Beck. Spats +1-->
-        <item offset="74" id="27440" /> <!--Beck. Pigaches +1-->
-        <item offset="75" id="26771" /> <!--Hashishin Kavuk +1-->
-        <item offset="76" id="26929" /> <!--Hashishin Mintan +1-->
-        <item offset="77" id="27083" /> <!--Hashi. Bazu. +1-->
-        <item offset="78" id="27268" /> <!--Hashishin Tayt +1-->
-        <item offset="79" id="27442" /> <!--Hashi. Basmak +1-->
-        <item offset="80" id="26773" /> <!--Chass. Tricorne +1-->
-        <item offset="81" id="26931" /> <!--Chasseur's Frac +1-->
-        <item offset="82" id="27085" /> <!--Chasseur's Gants +1-->
-        <item offset="83" id="27270" /> <!--Chas. Culottes +1-->
-        <item offset="84" id="27444" /> <!--Chass. Bottes +1-->
-        <item offset="85" id="26775" /> <!--Kara. Cappello +1-->
-        <item offset="86" id="26933" /> <!--Kara. Farsetto +1-->
-        <item offset="87" id="27087" /> <!--Karagoz Guanti +1-->
-        <item offset="88" id="27272" /> <!--Kara. Pantaloni +1-->
-        <item offset="89" id="27446" /> <!--Karagoz Scarpe +1-->
-        <item offset="90" id="26777" /> <!--Maculele Tiara +1-->
-        <item offset="91" id="26935" /> <!--Macu. Casaque +1-->
-        <item offset="92" id="27089" /> <!--Macu. Bangles +1-->
-        <item offset="93" id="27274" /> <!--Maculele Tights +1-->
-        <item offset="94" id="27448" /> <!--Macu. Toe Shoes +1-->
-        <item offset="95" id="26779" /> <!--Arbatel Bonnet +1-->
-        <item offset="96" id="26937" /> <!--Arbatel Gown +1-->
-        <item offset="97" id="27091" /> <!--Arbatel Bracers +1-->
-        <item offset="98" id="27276" /> <!--Arbatel Pants +1-->
-        <item offset="99" id="27450" /> <!--Arbatel Loafers +1-->
-        <item offset="100" id="26781" /> <!--Azimuth Hood +1-->
-        <item offset="101" id="26939" /> <!--Azimuth Coat +1-->
-        <item offset="102" id="27093" /> <!--Azimuth Gloves +1-->
-        <item offset="103" id="27278" /> <!--Azimuth Tights +1-->
-        <item offset="104" id="27452" /> <!--Azimuth Gaiters +1-->
-        <item offset="105" id="26783" /> <!--Erilaz Galea +1-->
-        <item offset="106" id="26941" /> <!--Erilaz Surcoat +1-->
-        <item offset="107" id="27095" /> <!--Erilaz Gauntlets +1-->
-        <item offset="108" id="27280" /> <!--Eri. Leg Guards +1-->
-        <item offset="109" id="27454" /> <!--Erilaz Greaves +1-->
-    </slip>
-    <slip id="29333">
-        <item offset="0" id="25639" /> <!--Korrigan Masque-->
-        <item offset="1" id="25715" /> <!--Korrigan Suit-->
-        <item offset="2" id="25638" /> <!--Pachy. Masque-->
-        <item offset="3" id="3707" /> <!--Murrey Grisaille-->
-        <item offset="4" id="3708" /> <!--Moss Gr. Grisaille-->
-        <item offset="5" id="21074" /> <!--Kupo Rod-->
-        <item offset="6" id="26406" /> <!--Kupo Shield-->
-        <item offset="7" id="25645" /> <!--Kupo Masque-->
-        <item offset="8" id="25726" /> <!--Kupo Suit-->
-        <item offset="9" id="25648" /> <!--Curm. Helmet-->
-        <item offset="10" id="25649" /> <!--Gazer's Helmet-->
-        <item offset="11" id="25650" /> <!--Retching Helmet-->
-        <item offset="12" id="25758" /> <!--Rhapsody Shirt-->
-        <item offset="13" id="25759" /> <!--Rhapsody Shirt +1-->
-        <item offset="14" id="25672" /> <!--Snoll Masque-->
-        <item offset="15" id="25673" /> <!--Snoll Masque +1-->
-        <item offset="16" id="282" /> <!--Yovra Replica-->
-        <item offset="17" id="279" /> <!--S. Lord Statue II-->
-        <item offset="18" id="280" /> <!--S. Lord Statue III-->
-        <item offset="19" id="268" /> <!--N. Moogle Statue-->
-        <item offset="20" id="25670" /> <!--Rarab Cap-->
-        <item offset="21" id="25671" /> <!--Rarab Cap +1-->
-        <item offset="22" id="26520" /> <!--Akitu Shirt-->
-        <item offset="23" id="25652" /> <!--Crab Cap-->
-        <item offset="24" id="25669" /> <!--Crab Cap +1-->
-        <item offset="25" id="22017" /> <!--Seika Uchiwa-->
-        <item offset="26" id="22018" /> <!--Seika Uchiwa +1-->
-        <item offset="27" id="25586" /> <!--Kakai Cap-->
-        <item offset="28" id="25587" /> <!--Kakai Cap +1-->
-        <item offset="29" id="10384" /> <!--Cumulus Masque-->
-        <item offset="30" id="10385" /> <!--Cumulus Masque +1-->
-        <item offset="31" id="22019" /> <!--Jingly Rod-->
-        <item offset="32" id="22020" /> <!--Jingly Rod +1-->
-        <item offset="33" id="25722" /> <!--Jubilee Shirt-->
-        <item offset="34" id="25585" /> <!--Bl. Chocobo Cap-->
-        <item offset="35" id="25776" /> <!--Bl. Chocobo Suit-->
-        <item offset="36" id="25677" /> <!--Arthro's Cap-->
-        <item offset="37" id="25678" /> <!--Arthro's Cap +1-->
-        <item offset="38" id="25675" /> <!--Wh. Rarab Cap-->
-        <item offset="39" id="25679" /> <!--Wh. Rarab Cap +1-->
-        <item offset="40" id="20668" /> <!--Firetongue-->
-        <item offset="41" id="20669" /> <!--Firetongue +1-->
-        <item offset="42" id="22069" /> <!--Hapy Staff-->
-        <item offset="43" id="25755" /> <!--Crustacean Shirt-->
-        <item offset="44" id="3722" /> <!--Lion Statue-->
-        <item offset="45" id="21608" /> <!--Onion Sword II-->
-        <item offset="46" id="3713" /> <!--Pot of Wards-->
-        <item offset="47" id="3714" /> <!--White Clematis-->
-        <item offset="48" id="3715" /> <!--Pink Clematis-->
-        <item offset="49" id="3717" /> <!--Birch Tree-->
-        <item offset="50" id="3727" /> <!--Mumor Statue-->
-        <item offset="51" id="3728" /> <!--Ullegore Statue-->
-        <item offset="52" id="20577" /> <!--Chicken Knife II-->
-        <item offset="53" id="3726" /> <!--Aphmau Statue-->
-        <item offset="54" id="20666" /> <!--Blizzard Brand-->
-        <item offset="55" id="20667" /> <!--Blizzard Brand +1-->
-        <item offset="56" id="21741" /> <!--Demonic Axe-->
-        <item offset="57" id="21609" /> <!--Save the Queen II-->
-        <item offset="58" id="3723" /> <!--Lilisette Statue-->
-        <item offset="59" id="26410" /> <!--Diamond Buckler-->
-        <item offset="60" id="26411" /> <!--Diamond Buckler +1-->
-        <item offset="61" id="25850" /> <!--Pink Subligar-->
-        <item offset="62" id="21509" /> <!--Premium Mogti-->
-        <item offset="63" id="3725" /> <!--Cornelia Statue-->
-        <item offset="64" id="3720" /> <!--Arciela Statue-->
-        <item offset="65" id="21658" /> <!--Brave Blade II-->
-        <item offset="66" id="26524" /> <!--Gil Nabber Shirt-->
-        <item offset="67" id="20665" /> <!--Kam'lanaut's Sword-->
-        <item offset="68" id="26412" /> <!--Kam'lanaut's Shield-->
-        <item offset="69" id="21965" /> <!--Zanmato-->
-        <item offset="70" id="21966" /> <!--Zanmato +1-->
-        <item offset="71" id="21967" /> <!--Melon Slicer-->
-        <item offset="72" id="25774" /> <!--Fancy Gilet-->
-        <item offset="73" id="25838" /> <!--Fancy Trunks-->
-        <item offset="74" id="25775" /> <!--Fancy Top-->
-        <item offset="75" id="25839" /> <!--Fancy Shorts-->
-        <item offset="76" id="3724" /> <!--Uka Statue-->
-        <item offset="77" id="3721" /> <!--Iroha Statue-->
-        <item offset="78" id="21682" /> <!--Lament-->
-        <item offset="79" id="22072" /> <!--Lamia Staff-->
-        <item offset="80" id="21820" /> <!--Lost Sickle-->
-        <item offset="81" id="21821" /> <!--Lost Sickle +1-->
-        <item offset="82" id="23731" /> <!--Ryl. Chocobo Beret-->
-        <item offset="83" id="26517" /> <!--Shadow Lord Shirt-->
-        <item offset="84" id="23730" /> <!--Karakul Cap-->
-        <item offset="85" id="20573" /> <!--Aern Dagger-->
-        <item offset="86" id="20674" /> <!--Aern Sword-->
-        <item offset="87" id="21742" /> <!--Aern Axe-->
-        <item offset="88" id="21860" /> <!--Aern Spear-->
-        <item offset="89" id="22065" /> <!--Aern Staff-->
-        <item offset="90" id="22039" /> <!--Floral Hagoita-->
-        <item offset="91" id="22124" /> <!--Artemis's Bow-->
-        <item offset="92" id="22132" /> <!--Artemis's Bow +1-->
-        <item offset="93" id="3719" /> <!--Prishe Statue II-->
-        <item offset="94" id="3738" /> <!--Eastern Umbrella-->
-        <item offset="95" id="26518" /> <!--Jody Shirt-->
-        <item offset="96" id="27623" /> <!--Jody Shield-->
-        <item offset="97" id="21867" /> <!--Sha Wujing's Lance-->
-        <item offset="98" id="21868" /> <!--Sha Wujing's La. +1-->
-        <item offset="99" id="22283" /> <!--Marvelous Cheer-->
-        <item offset="100" id="26516" /> <!--Citrullus Shirt-->
-        <item offset="101" id="20933" /> <!--Hotengeki-->
-        <item offset="102" id="20578" /> <!--Wind Knife-->
-        <item offset="103" id="20568" /> <!--Wind Knife +1-->
-        <item offset="104" id="3739" /> <!--Autumn Tree-->
-        <item offset="105" id="20569" /> <!--Esikuva-->
-        <item offset="106" id="20570" /> <!--Norgish Dagger-->
-        <item offset="107" id="22288" /> <!--Mandragora Pouch-->
-        <item offset="108" id="26352" /> <!--Moogle Sacoche-->
-        <item offset="109" id="23737" /> <!--Byakko Masque-->
-        <item offset="110" id="22282" /> <!--Grudge-->
-        <item offset="111" id="3740" /> <!--Model Synergy Furn.-->
-        <item offset="113" id="26545" /> <!--Mithkabob Shirt-->
-        <item offset="114" id="21977" /> <!--Mutsunokami-->
-        <item offset="115" id="21978" /> <!--Mutsunokami +1-->
-        <item offset="116" id="3742" /> <!--Merc. Painting-->
-        <item offset="117" id="26519" /> <!--Mandragora Shirt-->
-        <item offset="118" id="26514" /> <!--Poroggo Fleece-->
-        <item offset="119" id="26515" /> <!--Poroggo Fleece +1-->
-        <item offset="120" id="3743" /> <!--Moogle Bed-->
-        <item offset="121" id="21636" /> <!--Nihility-->
-        <item offset="122" id="23753" /> <!--Sandogasa-->
-        <item offset="123" id="23754" /> <!--Sandogasa +1-->
-        <item offset="124" id="54" /> <!--Chocobo Commode-->
-        <item offset="125" id="25910" /> <!--Cait Sith Subligar-->
-        <item offset="126" id="20571" /> <!--Infiltrator-->
-        <item offset="127" id="23790" /> <!--Adenium Masque-->
-        <item offset="128" id="23791" /> <!--Adenium Suit-->
-        <item offset="129" id="26489" /> <!--Troth-->
-        <item offset="130" id="22153" /> <!--Silver Gun-->
-        <item offset="131" id="22154" /> <!--Silver Gun +1-->
-        <item offset="132" id="20574" /> <!--Aern Dagger II-->
-        <item offset="133" id="20675" /> <!--Aern Sword II-->
-        <item offset="134" id="21743" /> <!--Aern Axe II-->
-        <item offset="135" id="21861" /> <!--Aern Spear II-->
-        <item offset="136" id="22066" /> <!--Aern Staff II-->
-        <item offset="137" id="3748" /> <!--Leafkin Bed-->
-        <item offset="138" id="21638" /> <!--Extinction-->
-        <item offset="139" id="23800" /> <!--Cancrine Apron-->
-        <item offset="140" id="23801" /> <!--Cancrine Apron +1-->
-        <item offset="141" id="3749" /> <!--Chemistry Set-->
-        <item offset="142" id="3750" /> <!--Qiqirn Sack-->
-        <item offset="143" id="22045" /> <!--Feline Hagoita-->
-        <item offset="144" id="22046" /> <!--Feline Hagoita +1-->
-        <item offset="145" id="3751" /> <!--Besigiled Table-->
-        <item offset="146" id="26490" /> <!--Ark Shield-->
-        <item offset="147" id="26546" /> <!--Moogle Shirt-->
-        <item offset="148" id="22047" /> <!--Korrigan Mallet-->
-        <item offset="149" id="22048" /> <!--Adenium Mallet-->
-        <item offset="150" id="22049" /> <!--Citrullus Mallet-->
-        <item offset="151" id="23803" /> <!--Poroggo Cassock-->
-        <item offset="152" id="23804" /> <!--Poroggo Cass. +1-->
-        <item offset="153" id="22051" /> <!--Lycopodium Mallet-->
-        <item offset="154" id="22052" /> <!--Summer Uchiwa-->
-        <item offset="155" id="3752" /> <!--Colibri Bed-->
-        <item offset="156" id="23805" /> <!--Morbol Apron-->
-        <item offset="157" id="25911" /> <!--Denim Pants-->
-        <item offset="158" id="25912" /> <!--Denim Pants +1-->
-        <item offset="159" id="3753" /> <!--Blueblade Fell-->
-        <item offset="160" id="23806" /> <!--Vaquero Hat-->
-        <item offset="161" id="3754" /> <!--Kagami Mochi-->
-        <item offset="162" id="23810" /> <!--Knit Cap-->
-        <item offset="163" id="23811" /> <!--Knit Cap +1-->
-        <item offset="164" id="3755" /> <!--Prismatic Chest-->
-        <item offset="165" id="26496" /> <!--Ageist-->
-        <item offset="166" id="26497" /> <!--Regis-->
-        <item offset="167" id="21786" /> <!--Poison Axe-->
-        <item offset="168" id="21787" /> <!--Poison Axe +1-->
-        <item offset="169" id="21996" /> <!--Magician's Rod-->
-        <item offset="170" id="21997" /> <!--Magician's Rod +1-->
-        <item offset="171" id="23802" /> <!--Aucuba Crown-->
-        <item offset="172" id="25777" /> <!--Iratsugo Happi-->
-        <item offset="173" id="25778" /> <!--Iratsume Happi-->
-        <item offset="174" id="21933" /> <!--Yagyu Shortblade-->
-        <item offset="175" id="21934" /> <!--Yagyu Short. +1-->
-        <item offset="176" id="21993" /> <!--Erudite's Staff-->
-        <item offset="177" id="21994" /> <!--Erudite's Staff +1-->
-    </slip>
-    <slip id="29334">
-        <item offset="0" id="25659" /> <!--Sulevia's Mask-->
-        <item offset="1" id="25745" /> <!--Sulevia's Plate.-->
-        <item offset="2" id="25800" /> <!--Sulevia's Gauntlets-->
-        <item offset="3" id="25858" /> <!--Sulevia's Cuisses-->
-        <item offset="4" id="25925" /> <!--Sulevia's Leggings-->
-        <item offset="5" id="25660" /> <!--Sulevia's Mask +1-->
-        <item offset="6" id="25746" /> <!--Sulevia's Plate. +1-->
-        <item offset="7" id="25801" /> <!--Sulev. Gauntlets +1-->
-        <item offset="8" id="25859" /> <!--Sulevi. Cuisses +1-->
-        <item offset="9" id="25926" /> <!--Sulev. Leggings +1-->
-        <item offset="10" id="25663" /> <!--Hizamaru Somen-->
-        <item offset="11" id="25749" /> <!--Hizamaru Haramaki-->
-        <item offset="12" id="25804" /> <!--Hizamaru Kote-->
-        <item offset="13" id="25862" /> <!--Hiza. Hizayoroi-->
-        <item offset="14" id="25929" /> <!--Hiza. Sune-Ate-->
-        <item offset="15" id="25664" /> <!--Hizamaru Somen +1-->
-        <item offset="16" id="25750" /> <!--Hiza. Haramaki +1-->
-        <item offset="17" id="25805" /> <!--Hizamaru Kote +1-->
-        <item offset="18" id="25863" /> <!--Hiza. Hizayoroi +1-->
-        <item offset="19" id="25930" /> <!--Hiza. Sune-Ate +1-->
-        <item offset="20" id="25665" /> <!--Inyanga Tiara-->
-        <item offset="21" id="25751" /> <!--Inyanga Jubbah-->
-        <item offset="22" id="25806" /> <!--Inyanga Dastanas-->
-        <item offset="23" id="25865" /> <!--Inyanga Shalwar-->
-        <item offset="24" id="25931" /> <!--Inyanga Crackows-->
-        <item offset="25" id="25666" /> <!--Inyanga Tiara +1-->
-        <item offset="26" id="25752" /> <!--Inyanga Jubbah +1-->
-        <item offset="27" id="25807" /> <!--Inyan. Dastanas +1-->
-        <item offset="28" id="25866" /> <!--Inyanga Shalwar +1-->
-        <item offset="29" id="25932" /> <!--Inyan. Crackows +1-->
-        <item offset="30" id="25661" /> <!--Meghanada Visor-->
-        <item offset="31" id="25747" /> <!--Meghanada Cuirie-->
-        <item offset="32" id="25802" /> <!--Meghanada Gloves-->
-        <item offset="33" id="25860" /> <!--Meg. Chausses-->
-        <item offset="34" id="25927" /> <!--Meg. Jambeaux-->
-        <item offset="35" id="25662" /> <!--Meghanada Visor +1-->
-        <item offset="36" id="25748" /> <!--Meg. Cuirie +1-->
-        <item offset="37" id="25803" /> <!--Meg. Gloves +1-->
-        <item offset="38" id="25861" /> <!--Meg. Chausses +1-->
-        <item offset="39" id="25928" /> <!--Meg. Jam. +1-->
-        <item offset="40" id="25667" /> <!--Jhakri Coronal-->
-        <item offset="41" id="25753" /> <!--Jhakri Robe-->
-        <item offset="42" id="25808" /> <!--Jhakri Cuffs-->
-        <item offset="43" id="25867" /> <!--Jhakri Slops-->
-        <item offset="44" id="25933" /> <!--Jhakri Pigaches-->
-        <item offset="45" id="25668" /> <!--Jhakri Coronal +1-->
-        <item offset="46" id="25754" /> <!--Jhakri Robe +1-->
-        <item offset="47" id="25809" /> <!--Jhakri Cuffs +1-->
-        <item offset="48" id="25868" /> <!--Jhakri Slops +1-->
-        <item offset="49" id="25934" /> <!--Jhakri Pigaches +1-->
-        <item offset="50" id="25579" /> <!--Flamma Zucchetto-->
-        <item offset="51" id="25779" /> <!--Flamma Korazin-->
-        <item offset="52" id="25818" /> <!--Flamma Manopolas-->
-        <item offset="53" id="25873" /> <!--Flamma Dirs-->
-        <item offset="54" id="25940" /> <!--Flamma Gambieras-->
-        <item offset="55" id="25580" /> <!--Flam. Zucchetto +1-->
-        <item offset="56" id="25780" /> <!--Flamma Korazin +1-->
-        <item offset="57" id="25819" /> <!--Flam. Manopolas +1-->
-        <item offset="58" id="25874" /> <!--Flamma Dirs +1-->
-        <item offset="59" id="25941" /> <!--Flam. Gambieras +1-->
-        <item offset="60" id="25590" /> <!--Tali'ah Turban-->
-        <item offset="61" id="25764" /> <!--Tali'ah Manteel-->
-        <item offset="62" id="25812" /> <!--Tali'ah Gages-->
-        <item offset="63" id="25871" /> <!--Tali'ah Seraweels-->
-        <item offset="64" id="25937" /> <!--Tali'ah Crackows-->
-        <item offset="65" id="25591" /> <!--Tali'ah Turban +1-->
-        <item offset="66" id="25765" /> <!--Tali'ah Manteel +1-->
-        <item offset="67" id="25813" /> <!--Tali'ah Gages +1-->
-        <item offset="68" id="25872" /> <!--Tali'ah Sera. +1-->
-        <item offset="69" id="25938" /> <!--Tali'ah Crackows +1-->
-        <item offset="70" id="25581" /> <!--Mummu Bonnet-->
-        <item offset="71" id="25781" /> <!--Mummu Jacket-->
-        <item offset="72" id="25820" /> <!--Mummu Wrists-->
-        <item offset="73" id="25875" /> <!--Mummu Kecks-->
-        <item offset="74" id="25942" /> <!--Mummu Gamashes-->
-        <item offset="75" id="25582" /> <!--Mummu Bonnet +1-->
-        <item offset="76" id="25782" /> <!--Mummu Jacket +1-->
-        <item offset="77" id="25821" /> <!--Mummu Wrists +1-->
-        <item offset="78" id="25876" /> <!--Mummu Kecks +1-->
-        <item offset="79" id="25943" /> <!--Mummu Gamash. +1-->
-        <item offset="80" id="25588" /> <!--Aya. Zucchetto-->
-        <item offset="81" id="25762" /> <!--Ayanmo Corazza-->
-        <item offset="82" id="25810" /> <!--Aya. Manopolas-->
-        <item offset="83" id="25869" /> <!--Ayanmo Cosciales-->
-        <item offset="84" id="25935" /> <!--Aya. Gambieras-->
-        <item offset="85" id="25589" /> <!--Aya. Zucchetto +1-->
-        <item offset="86" id="25763" /> <!--Ayanmo Corazza +1-->
-        <item offset="87" id="25811" /> <!--Aya. Manopolas +1-->
-        <item offset="88" id="25870" /> <!--Aya. Cosciales +1-->
-        <item offset="89" id="25936" /> <!--Aya. Gambieras +1-->
-        <item offset="90" id="25583" /> <!--Mallquis Chapeau-->
-        <item offset="91" id="25783" /> <!--Mallquis Saio-->
-        <item offset="92" id="25822" /> <!--Mallquis Cuffs-->
-        <item offset="93" id="25877" /> <!--Mallquis Trews-->
-        <item offset="94" id="25944" /> <!--Mallquis Clogs-->
-        <item offset="95" id="25584" /> <!--Mallquis Chapeau +1-->
-        <item offset="96" id="25784" /> <!--Mallquis Saio +1-->
-        <item offset="97" id="25823" /> <!--Mallquis Cuffs +1-->
-        <item offset="98" id="25878" /> <!--Mallquis Trews +1-->
-        <item offset="99" id="25945" /> <!--Mallquis Clogs +1-->
-        <item offset="100" id="25574" /> <!--Sulevia's Mask +2-->
-        <item offset="101" id="25790" /> <!--Sulevia's Plate. +2-->
-        <item offset="102" id="25828" /> <!--Sulev. Gauntlets +2-->
-        <item offset="103" id="25879" /> <!--Sulev. Cuisses +2-->
-        <item offset="104" id="25946" /> <!--Sulev. Leggings +2-->
-        <item offset="105" id="25575" /> <!--Meghanada Visor +2-->
-        <item offset="106" id="25791" /> <!--Meg. Cuirie +2-->
-        <item offset="107" id="25829" /> <!--Meg. Gloves +2-->
-        <item offset="108" id="25880" /> <!--Meg. Chausses +2-->
-        <item offset="109" id="25947" /> <!--Meg. Jam. +2-->
-        <item offset="110" id="25576" /> <!--Hiza. Somen +2-->
-        <item offset="111" id="25792" /> <!--Hiza. Haramaki +2-->
-        <item offset="112" id="25830" /> <!--Hizamaru Kote +2-->
-        <item offset="113" id="25881" /> <!--Hiza. Hizayoroi +2-->
-        <item offset="114" id="25948" /> <!--Hiza. Sune-Ate +2-->
-        <item offset="115" id="25577" /> <!--Inyanga Tiara +2-->
-        <item offset="116" id="25793" /> <!--Inyanga Jubbah +2-->
-        <item offset="117" id="25831" /> <!--Inyan. Dastanas +2-->
-        <item offset="118" id="25882" /> <!--Inyanga Shalwar +2-->
-        <item offset="119" id="25949" /> <!--Inyan. Crackows +2-->
-        <item offset="120" id="25578" /> <!--Jhakri Coronal +2-->
-        <item offset="121" id="25794" /> <!--Jhakri Robe +2-->
-        <item offset="122" id="25832" /> <!--Jhakri Cuffs +2-->
-        <item offset="123" id="25883" /> <!--Jhakri Slops +2-->
-        <item offset="124" id="25950" /> <!--Jhakri Pigaches +2-->
-        <item offset="125" id="26204" /> <!--Sulevia's Ring-->
-        <item offset="126" id="26205" /> <!--Meghanada Ring-->
-        <item offset="127" id="26206" /> <!--Hizamaru Ring-->
-        <item offset="128" id="26207" /> <!--Inyanga Ring-->
-        <item offset="129" id="26208" /> <!--Jhakri Ring-->
-        <item offset="130" id="25569" /> <!--Flam. Zucchetto +2-->
-        <item offset="131" id="25797" /> <!--Flamma Korazin +2-->
-        <item offset="132" id="25835" /> <!--Flam. Manopolas +2-->
-        <item offset="133" id="25886" /> <!--Flamma Dirs +2-->
-        <item offset="134" id="25953" /> <!--Flam. Gambieras +2-->
-        <item offset="135" id="25573" /> <!--Tali'ah Turban +2-->
-        <item offset="136" id="25796" /> <!--Tali'ah Manteel +2-->
-        <item offset="137" id="25834" /> <!--Tali'ah Gages +2-->
-        <item offset="138" id="25885" /> <!--Tali'ah Sera. +2-->
-        <item offset="139" id="25952" /> <!--Tali'ah Crackows +2-->
-        <item offset="140" id="25570" /> <!--Mummu Bonnet +2-->
-        <item offset="141" id="25798" /> <!--Mummu Jacket +2-->
-        <item offset="142" id="25836" /> <!--Mummu Wrists +2-->
-        <item offset="143" id="25887" /> <!--Mummu Kecks +2-->
-        <item offset="144" id="25954" /> <!--Mummu Gamash. +2-->
-        <item offset="145" id="25572" /> <!--Aya. Zucchetto +2-->
-        <item offset="146" id="25795" /> <!--Ayanmo Corazza +2-->
-        <item offset="147" id="25833" /> <!--Aya. Manopolas +2-->
-        <item offset="148" id="25884" /> <!--Aya. Cosciales +2-->
-        <item offset="149" id="25951" /> <!--Aya. Gambieras +2-->
-        <item offset="150" id="25571" /> <!--Mall. Chapeau +2-->
-        <item offset="151" id="25799" /> <!--Mallquis Saio +2-->
-        <item offset="152" id="25837" /> <!--Mallquis Cuffs +2-->
-        <item offset="153" id="25888" /> <!--Mallquis Trews +2-->
-        <item offset="154" id="25955" /> <!--Mallquis Clogs +2-->
-        <item offset="155" id="26211" /> <!--Flamma Ring-->
-        <item offset="156" id="26210" /> <!--Tali'ah Ring-->
-        <item offset="157" id="26212" /> <!--Mummu Ring-->
-        <item offset="158" id="26209" /> <!--Ayanmo Ring-->
-        <item offset="159" id="26213" /> <!--Mallquis Ring-->
-        <item offset="160" id="21863" /> <!--Tzee Xicu's Blade-->
-        <item offset="161" id="22004" /> <!--Soulflayer's Wand-->
-        <item offset="162" id="21744" /> <!--Gramk's Axe-->
-        <item offset="163" id="21272" /> <!--Troll Gun-->
-        <item offset="164" id="20576" /> <!--Qutrub Knife-->
-        <item offset="165" id="21761" /> <!--Za'Dha Chopper-->
-        <item offset="166" id="26409" /> <!--Dullahan Shield-->
-        <item offset="167" id="22070" /> <!--Ranine Staff-->
-        <item offset="168" id="21681" /> <!--Ophidian Sword-->
-        <item offset="169" id="22005" /> <!--Burrower's Wand-->
-        <item offset="170" id="21745" /> <!--Dullahan Axe-->
-        <item offset="171" id="22068" /> <!--Savage. Pole-->
-        <item offset="172" id="21759" /> <!--Autarch's Axe-->
-        <item offset="173" id="21770" /> <!--Helgoland-->
-        <item offset="174" id="22067" /> <!--Levin-->
-        <item offset="175" id="21680" /> <!--Goujian-->
-        <item offset="176" id="22071" /> <!--Profane Staff-->
-    </slip>
-    <slip id="29335">
-        <item offset="0" id="23040" /> <!--Pummeler's Mask +2-->
-        <item offset="1" id="23107" /> <!--Pumm. Lorica +2-->
-        <item offset="2" id="23174" /> <!--Pumm. Mufflers +2-->
-        <item offset="3" id="23241" /> <!--Pumm. Cuisses +2-->
-        <item offset="4" id="23308" /> <!--Pumm. Calligae +2-->
-        <item offset="5" id="23041" /> <!--Anch. Crown +2-->
-        <item offset="6" id="23108" /> <!--Anch. Cyclas +2-->
-        <item offset="7" id="23175" /> <!--Anchor. Gloves +2-->
-        <item offset="8" id="23242" /> <!--Anch. Hose +2-->
-        <item offset="9" id="23309" /> <!--Anch. Gaiters +2-->
-        <item offset="10" id="23042" /> <!--Theophany Cap +2-->
-        <item offset="11" id="23109" /> <!--Theo. Bliaut +2-->
-        <item offset="12" id="23176" /> <!--Theophany Mitts +2-->
-        <item offset="13" id="23243" /> <!--Th. Pantaloons +2-->
-        <item offset="14" id="23310" /> <!--Theo. Duckbills +2-->
-        <item offset="15" id="23043" /> <!--Spae. Petasos +2-->
-        <item offset="16" id="23110" /> <!--Spaekona's Coat +2-->
-        <item offset="17" id="23177" /> <!--Spae. Gloves +2-->
-        <item offset="18" id="23244" /> <!--Spae. Tonban +2-->
-        <item offset="19" id="23311" /> <!--Spae. Sabots +2-->
-        <item offset="20" id="23044" /> <!--Atro. Chapeau +2-->
-        <item offset="21" id="23111" /> <!--Atrophy Tabard +2-->
-        <item offset="22" id="23178" /> <!--Atrophy Gloves +2-->
-        <item offset="23" id="23245" /> <!--Atrophy Tights +2-->
-        <item offset="24" id="23312" /> <!--Atro. Boots +2-->
-        <item offset="25" id="23045" /> <!--Pill. Bonnet +2-->
-        <item offset="26" id="23112" /> <!--Pillager's Vest +2-->
-        <item offset="27" id="23179" /> <!--Pill. Armlets +2-->
-        <item offset="28" id="23246" /> <!--Pill. Culottes +2-->
-        <item offset="29" id="23313" /> <!--Pill. Poulaines +2-->
-        <item offset="30" id="23046" /> <!--Rev. Coronet +2-->
-        <item offset="31" id="23113" /> <!--Rev. Surcoat +2-->
-        <item offset="32" id="23180" /> <!--Rev. Gauntlets +2-->
-        <item offset="33" id="23247" /> <!--Rev. Breeches +2-->
-        <item offset="34" id="23314" /> <!--Rev. Leggings +2-->
-        <item offset="35" id="23047" /> <!--Ig. Burgeonet +2-->
-        <item offset="36" id="23114" /> <!--Ignominy Cuirass +2-->
-        <item offset="37" id="23181" /> <!--Ig. Gauntlets +2-->
-        <item offset="38" id="23248" /> <!--Ig. Flanchard +2-->
-        <item offset="39" id="23315" /> <!--Ig. Sollerets +2-->
-        <item offset="40" id="23048" /> <!--Totemic Helm +2-->
-        <item offset="41" id="23115" /> <!--Tot. Jackcoat +2-->
-        <item offset="42" id="23182" /> <!--Totemic Gloves +2-->
-        <item offset="43" id="23249" /> <!--Tot. Trousers +2-->
-        <item offset="44" id="23316" /> <!--Tot. Gaiters +2-->
-        <item offset="45" id="23049" /> <!--Brioso Roundlet +2-->
-        <item offset="46" id="23116" /> <!--Brioso Justau. +2-->
-        <item offset="47" id="23183" /> <!--Brioso Cuffs +2-->
-        <item offset="48" id="23250" /> <!--Brioso Cannions +2-->
-        <item offset="49" id="23317" /> <!--Brioso Slippers +2-->
-        <item offset="50" id="23050" /> <!--Orion Beret +2-->
-        <item offset="51" id="23117" /> <!--Orion Jerkin +2-->
-        <item offset="52" id="23184" /> <!--Orion Bracers +2-->
-        <item offset="53" id="23251" /> <!--Orion Braccae +2-->
-        <item offset="54" id="23318" /> <!--Orion Socks +2-->
-        <item offset="55" id="23051" /> <!--Wakido Kabuto +2-->
-        <item offset="56" id="23118" /> <!--Wakido Domaru +2-->
-        <item offset="57" id="23185" /> <!--Wakido Kote +2-->
-        <item offset="58" id="23252" /> <!--Wakido Haidate +2-->
-        <item offset="59" id="23319" /> <!--Wakido Sune. +2-->
-        <item offset="60" id="23052" /> <!--Hachiya Hatsu. +2-->
-        <item offset="61" id="23119" /> <!--Hachiya Chain. +2-->
-        <item offset="62" id="23186" /> <!--Hachiya Tekko +2-->
-        <item offset="63" id="23253" /> <!--Hachiya Hakama +2-->
-        <item offset="64" id="23320" /> <!--Hachiya Kyahan +2-->
-        <item offset="65" id="23053" /> <!--Vishap Armet +2-->
-        <item offset="66" id="23120" /> <!--Vishap Mail +2-->
-        <item offset="67" id="23187" /> <!--Vis. Fng. Gaunt. +2-->
-        <item offset="68" id="23254" /> <!--Vishap Brais +2-->
-        <item offset="69" id="23321" /> <!--Vishap Greaves +2-->
-        <item offset="70" id="23054" /> <!--Convoker's Horn +2-->
-        <item offset="71" id="23121" /> <!--Con. Doublet +2-->
-        <item offset="72" id="23188" /> <!--Convo. Bracers +2-->
-        <item offset="73" id="23255" /> <!--Convo. Spats +2-->
-        <item offset="74" id="23322" /> <!--Convo. Pigaches +2-->
-        <item offset="75" id="23055" /> <!--Assim. Keffiyeh +2-->
-        <item offset="76" id="23122" /> <!--Assim. Jubbah +2-->
-        <item offset="77" id="23189" /> <!--Assim. Bazu. +2-->
-        <item offset="78" id="23256" /> <!--Assim. Shalwar +2-->
-        <item offset="79" id="23323" /> <!--Assim. Charuqs +2-->
-        <item offset="80" id="23056" /> <!--Laksa. Tricorne +2-->
-        <item offset="81" id="23123" /> <!--Laksa. Frac +2-->
-        <item offset="82" id="23190" /> <!--Laksa. Gants +2-->
-        <item offset="83" id="23257" /> <!--Laksa. Trews +2-->
-        <item offset="84" id="23324" /> <!--Laksa. Bottes +2-->
-        <item offset="85" id="23057" /> <!--Foire Taj +2-->
-        <item offset="86" id="23124" /> <!--Foire Tobe +2-->
-        <item offset="87" id="23191" /> <!--Foire Dastanas +2-->
-        <item offset="88" id="23258" /> <!--Foire Churidars +2-->
-        <item offset="89" id="23325" /> <!--Foire Babouches +2-->
-        <item offset="90" id="23058" /> <!--Maxixi Tiara +2-->
-        <item offset="91" id="23125" /> <!--Maxixi Casaque +2-->
-        <item offset="92" id="23192" /> <!--Maxixi Bangles +2-->
-        <item offset="93" id="23259" /> <!--Maxixi Tights +2-->
-        <item offset="94" id="23326" /> <!--Maxixi Toe Shoes +2-->
-        <item offset="95" id="23059" /> <!--Maxixi Tiara +2-->
-        <item offset="96" id="23126" /> <!--Maxixi Casaque +2-->
-        <item offset="97" id="23193" /> <!--Maxixi Bangles +2-->
-        <item offset="98" id="23260" /> <!--Maxixi Tights +2-->
-        <item offset="99" id="23327" /> <!--Maxixi Toe Shoes +2-->
-        <item offset="100" id="23060" /> <!--Acad. Mortar. +2-->
-        <item offset="101" id="23127" /> <!--Acad. Gown +2-->
-        <item offset="102" id="23194" /> <!--Acad. Bracers +2-->
-        <item offset="103" id="23261" /> <!--Acad. Pants +2-->
-        <item offset="104" id="23328" /> <!--Acad. Loafers +2-->
-        <item offset="105" id="23061" /> <!--Geo. Galero +2-->
-        <item offset="106" id="23128" /> <!--Geomancy Tunic +2-->
-        <item offset="107" id="23195" /> <!--Geo. Mitaines +2-->
-        <item offset="108" id="23262" /> <!--Geomancy Pants +2-->
-        <item offset="109" id="23329" /> <!--Geo. Sandals +2-->
-        <item offset="110" id="23062" /> <!--Rune. Bandeau +2-->
-        <item offset="111" id="23129" /> <!--Runeist Coat +2-->
-        <item offset="112" id="23196" /> <!--Runeist Mitons +2-->
-        <item offset="113" id="23263" /> <!--Rune. Trousers +2-->
-        <item offset="114" id="23330" /> <!--Runeist Bottes +2-->
-    </slip>
-    <slip id="29336">
-        <item offset="0" id="23375" /> <!--Pummeler's Mask +3-->
-        <item offset="1" id="23442" /> <!--Pumm. Lorica +3-->
-        <item offset="2" id="23509" /> <!--Pumm. Mufflers +3-->
-        <item offset="3" id="23576" /> <!--Pumm. Cuisses +3-->
-        <item offset="4" id="23643" /> <!--Pumm. Calligae +3-->
-        <item offset="5" id="23376" /> <!--Anch. Crown +3-->
-        <item offset="6" id="23443" /> <!--Anch. Cyclas +3-->
-        <item offset="7" id="23510" /> <!--Anchor. Gloves +3-->
-        <item offset="8" id="23577" /> <!--Anch. Hose +3-->
-        <item offset="9" id="23644" /> <!--Anch. Gaiters +3-->
-        <item offset="10" id="23377" /> <!--Theophany Cap +3-->
-        <item offset="11" id="23444" /> <!--Theo. Bliaut +3-->
-        <item offset="12" id="23511" /> <!--Theophany Mitts +3-->
-        <item offset="13" id="23578" /> <!--Th. Pant. +3-->
-        <item offset="14" id="23645" /> <!--Theo. Duckbills +3-->
-        <item offset="15" id="23378" /> <!--Spae. Petasos +3-->
-        <item offset="16" id="23445" /> <!--Spaekona's Coat +3-->
-        <item offset="17" id="23512" /> <!--Spae. Gloves +3-->
-        <item offset="18" id="23579" /> <!--Spae. Tonban +3-->
-        <item offset="19" id="23646" /> <!--Spae. Sabots +3-->
-        <item offset="20" id="23379" /> <!--Atrophy Chapeau +3-->
-        <item offset="21" id="23446" /> <!--Atrophy Tabard +3-->
-        <item offset="22" id="23513" /> <!--Atrophy Gloves +3-->
-        <item offset="23" id="23580" /> <!--Atrophy Tights +3-->
-        <item offset="24" id="23647" /> <!--Atro. Boots +3-->
-        <item offset="25" id="23380" /> <!--Pill. Bonnet +3-->
-        <item offset="26" id="23447" /> <!--Pillager's Vest +3-->
-        <item offset="27" id="23514" /> <!--Pill. Armlets +3-->
-        <item offset="28" id="23581" /> <!--Pill. Culottes +3-->
-        <item offset="29" id="23648" /> <!--Pill. Poulaines +3-->
-        <item offset="30" id="23381" /> <!--Rev. Coronet +3-->
-        <item offset="31" id="23448" /> <!--Rev. Surcoat +3-->
-        <item offset="32" id="23515" /> <!--Rev. Gauntlets +3-->
-        <item offset="33" id="23582" /> <!--Rev. Breeches +3-->
-        <item offset="34" id="23649" /> <!--Rev. Leggings +3-->
-        <item offset="35" id="23382" /> <!--Ig. Burgeonet +3-->
-        <item offset="36" id="23449" /> <!--Ignominy Cuirass +3-->
-        <item offset="37" id="23516" /> <!--Ig. Gauntlets +3-->
-        <item offset="38" id="23583" /> <!--Ig. Flanchard +3-->
-        <item offset="39" id="23650" /> <!--Ig. Sollerets +3-->
-        <item offset="40" id="23383" /> <!--Totemic Helm +3-->
-        <item offset="41" id="23450" /> <!--Tot. Jackcoat +3-->
-        <item offset="42" id="23517" /> <!--Totemic Gloves +3-->
-        <item offset="43" id="23584" /> <!--Tot. Trousers +3-->
-        <item offset="44" id="23651" /> <!--Tot. Gaiters +3-->
-        <item offset="45" id="23384" /> <!--Brioso Roundlet +3-->
-        <item offset="46" id="23451" /> <!--Brioso Justau. +3-->
-        <item offset="47" id="23518" /> <!--Brioso Cuffs +3-->
-        <item offset="48" id="23585" /> <!--Brioso Cannions +3-->
-        <item offset="49" id="23652" /> <!--Brioso Slippers +3-->
-        <item offset="50" id="23385" /> <!--Orion Beret +3-->
-        <item offset="51" id="23452" /> <!--Orion Jerkin +3-->
-        <item offset="52" id="23519" /> <!--Orion Bracers +3-->
-        <item offset="53" id="23586" /> <!--Orion Braccae +3-->
-        <item offset="54" id="23653" /> <!--Orion Socks +3-->
-        <item offset="55" id="23386" /> <!--Wakido Kabuto +3-->
-        <item offset="56" id="23453" /> <!--Wakido Domaru +3-->
-        <item offset="57" id="23520" /> <!--Wakido Kote +3-->
-        <item offset="58" id="23587" /> <!--Wakido Haidate +3-->
-        <item offset="59" id="23654" /> <!--Wakido Sune. +3-->
-        <item offset="60" id="23387" /> <!--Hachiya Hatsu. +3-->
-        <item offset="61" id="23454" /> <!--Hachiya Chain. +3-->
-        <item offset="62" id="23521" /> <!--Hachiya Tekko +3-->
-        <item offset="63" id="23588" /> <!--Hachiya Hakama +3-->
-        <item offset="64" id="23655" /> <!--Hachiya Kyahan +3-->
-        <item offset="65" id="23388" /> <!--Vishap Armet +3-->
-        <item offset="66" id="23455" /> <!--Vishap Mail +3-->
-        <item offset="67" id="23522" /> <!--Vis. Fng. Gaunt. +3-->
-        <item offset="68" id="23589" /> <!--Vishap Brais +3-->
-        <item offset="69" id="23656" /> <!--Vishap Greaves +3-->
-        <item offset="70" id="23389" /> <!--Convoker's Horn +3-->
-        <item offset="71" id="23456" /> <!--Con. Doublet +3-->
-        <item offset="72" id="23523" /> <!--Convo. Bracers +3-->
-        <item offset="73" id="23590" /> <!--Convo. Spats +3-->
-        <item offset="74" id="23657" /> <!--Convo. Pigaches +3-->
-        <item offset="75" id="23390" /> <!--Assim. Keffiyeh +3-->
-        <item offset="76" id="23457" /> <!--Assim. Jubbah +3-->
-        <item offset="77" id="23524" /> <!--Assim. Bazu. +3-->
-        <item offset="78" id="23591" /> <!--Assim. Shalwar +3-->
-        <item offset="79" id="23658" /> <!--Assim. Charuqs +3-->
-        <item offset="80" id="23391" /> <!--Laksa. Tricorne +3-->
-        <item offset="81" id="23458" /> <!--Laksa. Frac +3-->
-        <item offset="82" id="23525" /> <!--Laksa. Gants +3-->
-        <item offset="83" id="23592" /> <!--Laksa. Trews +3-->
-        <item offset="84" id="23659" /> <!--Laksa. Bottes +3-->
-        <item offset="85" id="23392" /> <!--Foire Taj +3-->
-        <item offset="86" id="23459" /> <!--Foire Tobe +3-->
-        <item offset="87" id="23526" /> <!--Foire Dastanas +3-->
-        <item offset="88" id="23593" /> <!--Foire Churidars +3-->
-        <item offset="89" id="23660" /> <!--Foire Babouches +3-->
-        <item offset="90" id="23393" /> <!--Maxixi Tiara +3-->
-        <item offset="91" id="23460" /> <!--Maxixi Casaque +3-->
-        <item offset="92" id="23527" /> <!--Maxixi Bangles +3-->
-        <item offset="93" id="23594" /> <!--Maxixi Tights +3-->
-        <item offset="94" id="23661" /> <!--Maxixi Toe Shoes +3-->
-        <item offset="95" id="23394" /> <!--Maxixi Tiara +3-->
-        <item offset="96" id="23461" /> <!--Maxixi Casaque +3-->
-        <item offset="97" id="23528" /> <!--Maxixi Bangles +3-->
-        <item offset="98" id="23595" /> <!--Maxixi Tights +3-->
-        <item offset="99" id="23662" /> <!--Maxixi Toe Shoes +3-->
-        <item offset="100" id="23395" /> <!--Acad. Mortar. +3-->
-        <item offset="101" id="23462" /> <!--Acad. Gown +3-->
-        <item offset="102" id="23529" /> <!--Acad. Bracers +3-->
-        <item offset="103" id="23596" /> <!--Acad. Pants +3-->
-        <item offset="104" id="23663" /> <!--Acad. Loafers +3-->
-        <item offset="105" id="23396" /> <!--Geo. Galero +3-->
-        <item offset="106" id="23463" /> <!--Geomancy Tunic +3-->
-        <item offset="107" id="23530" /> <!--Geo. Mitaines +3-->
-        <item offset="108" id="23597" /> <!--Geomancy Pants +3-->
-        <item offset="109" id="23664" /> <!--Geo. Sandals +3-->
-        <item offset="110" id="23397" /> <!--Rune. Bandeau +3-->
-        <item offset="111" id="23464" /> <!--Runeist Coat +3-->
-        <item offset="112" id="23531" /> <!--Runeist Mitons +3-->
-        <item offset="113" id="23598" /> <!--Rune. Trousers +3-->
-        <item offset="114" id="23665" /> <!--Runeist Bottes +3-->
-    </slip>
-    <slip id="29337">
-        <item offset="0" id="23063" /> <!--Agoge Mask +2-->
-        <item offset="1" id="23130" /> <!--Agoge Lorica +2-->
-        <item offset="2" id="23197" /> <!--Agoge Mufflers +2-->
-        <item offset="3" id="23264" /> <!--Agoge Cuisses +2-->
-        <item offset="4" id="23331" /> <!--Agoge Calligae +2-->
-        <item offset="5" id="23064" /> <!--Hes. Crown +2-->
-        <item offset="6" id="23131" /> <!--Hes. Cyclas +2-->
-        <item offset="7" id="23198" /> <!--Hes. Gloves +2-->
-        <item offset="8" id="23265" /> <!--Hes. Hose +2-->
-        <item offset="9" id="23332" /> <!--Hes. Gaiters +2-->
-        <item offset="10" id="23065" /> <!--Piety Cap +2-->
-        <item offset="11" id="23132" /> <!--Piety Bliaut +2-->
-        <item offset="12" id="23199" /> <!--Piety Mitts +2-->
-        <item offset="13" id="23266" /> <!--Piety Pantaln. +2-->
-        <item offset="14" id="23333" /> <!--Piety Duckbills +2-->
-        <item offset="15" id="23066" /> <!--Arch. Petasos +2-->
-        <item offset="16" id="23133" /> <!--Arch. Coat +2-->
-        <item offset="17" id="23200" /> <!--Arch. Gloves +2-->
-        <item offset="18" id="23267" /> <!--Arch. Tonban +2-->
-        <item offset="19" id="23334" /> <!--Arch. Sabots +2-->
-        <item offset="20" id="23067" /> <!--Viti. Chapeau +2-->
-        <item offset="21" id="23134" /> <!--Viti. Tabard +2-->
-        <item offset="22" id="23201" /> <!--Viti. Gloves +2-->
-        <item offset="23" id="23268" /> <!--Viti. Tights +2-->
-        <item offset="24" id="23335" /> <!--Vitiation Boots +2-->
-        <item offset="25" id="23068" /> <!--Plun. Bonnet +2-->
-        <item offset="26" id="23135" /> <!--Plunderer's Vest +2-->
-        <item offset="27" id="23202" /> <!--Plun. Armlets +2-->
-        <item offset="28" id="23269" /> <!--Plun. Culottes +2-->
-        <item offset="29" id="23336" /> <!--Plun. Poulaines +2-->
-        <item offset="30" id="23069" /> <!--Cab. Coronet +2-->
-        <item offset="31" id="23136" /> <!--Cab. Surcoat +2-->
-        <item offset="32" id="23203" /> <!--Cab. Gauntlets +2-->
-        <item offset="33" id="23270" /> <!--Cab. Breeches +2-->
-        <item offset="34" id="23337" /> <!--Cab. Leggings +2-->
-        <item offset="35" id="23070" /> <!--Fall. Burgeonet +2-->
-        <item offset="36" id="23137" /> <!--Fall. Cuirass +2-->
-        <item offset="37" id="23204" /> <!--Fall. Fin. Gaunt. +2-->
-        <item offset="38" id="23271" /> <!--Fall. Flanchard +2-->
-        <item offset="39" id="23338" /> <!--Fall. Sollerets +2-->
-        <item offset="40" id="23071" /> <!--Ankusa Helm +2-->
-        <item offset="41" id="23138" /> <!--An. Jackcoat +2-->
-        <item offset="42" id="23205" /> <!--Ankusa Gloves +2-->
-        <item offset="43" id="23272" /> <!--Ankusa Trousers +2-->
-        <item offset="44" id="23339" /> <!--Ankusa Gaiters +2-->
-        <item offset="45" id="23072" /> <!--Bihu Roundlet +2-->
-        <item offset="46" id="23139" /> <!--Bihu Jstcorps. +2-->
-        <item offset="47" id="23206" /> <!--Bihu Cuffs +2-->
-        <item offset="48" id="23273" /> <!--Bihu Cannions +2-->
-        <item offset="49" id="23340" /> <!--Bihu Slippers +2-->
-        <item offset="50" id="23073" /> <!--Arcadian Beret +2-->
-        <item offset="51" id="23140" /> <!--Arc. Jerkin +2-->
-        <item offset="52" id="23207" /> <!--Arc. Bracers +2-->
-        <item offset="53" id="23274" /> <!--Arc. Braccae +2-->
-        <item offset="54" id="23341" /> <!--Arcadian Socks +2-->
-        <item offset="55" id="23074" /> <!--Sakonji Kabuto +2-->
-        <item offset="56" id="23141" /> <!--Sakonji Domaru +2-->
-        <item offset="57" id="23208" /> <!--Sakonji Kote +2-->
-        <item offset="58" id="23275" /> <!--Sakonji Haidate +2-->
-        <item offset="59" id="23342" /> <!--Sak. Sune-Ate +2-->
-        <item offset="60" id="23075" /> <!--Mochi. Hatsuburi +2-->
-        <item offset="61" id="23142" /> <!--Mochi. Chainmail +2-->
-        <item offset="62" id="23209" /> <!--Mochizuki Tekko +2-->
-        <item offset="63" id="23276" /> <!--Mochi. Hakama +2-->
-        <item offset="64" id="23343" /> <!--Mochi. Kyahan +2-->
-        <item offset="65" id="23076" /> <!--Ptero. Armet +2-->
-        <item offset="66" id="23143" /> <!--Ptero. Mail +2-->
-        <item offset="67" id="23210" /> <!--Ptero. Fin. G. +2-->
-        <item offset="68" id="23277" /> <!--Ptero. Brais +2-->
-        <item offset="69" id="23344" /> <!--Ptero. Greaves +2-->
-        <item offset="70" id="23077" /> <!--Glyphic Horn +2-->
-        <item offset="71" id="23144" /> <!--Glyphic Doublet +2-->
-        <item offset="72" id="23211" /> <!--Glyphic Bracers +2-->
-        <item offset="73" id="23278" /> <!--Glyphic Spats +2-->
-        <item offset="74" id="23345" /> <!--Glyph. Pigaches +2-->
-        <item offset="75" id="23078" /> <!--Luh. Keffiyeh +2-->
-        <item offset="76" id="23145" /> <!--Luhlaza Jubbah +2-->
-        <item offset="77" id="23212" /> <!--Luh. Bazubands +2-->
-        <item offset="78" id="23279" /> <!--Luhlaza Shalwar +2-->
-        <item offset="79" id="23346" /> <!--Luhlaza Charuqs +2-->
-        <item offset="80" id="23079" /> <!--Lanun Tricorne +2-->
-        <item offset="81" id="23146" /> <!--Lanun Frac +2-->
-        <item offset="82" id="23213" /> <!--Lanun Gants +2-->
-        <item offset="83" id="23280" /> <!--Lanun Trews +2-->
-        <item offset="84" id="23347" /> <!--Lanun Bottes +2-->
-        <item offset="85" id="23080" /> <!--Pitre Taj +2-->
-        <item offset="86" id="23147" /> <!--Pitre Tobe +2-->
-        <item offset="87" id="23214" /> <!--Pitre Dastanas +2-->
-        <item offset="88" id="23281" /> <!--Pitre Churidars +2-->
-        <item offset="89" id="23348" /> <!--Pitre Babouches +2-->
-        <item offset="90" id="23081" /> <!--Horos Tiara +2-->
-        <item offset="91" id="23148" /> <!--Horos Casaque +2-->
-        <item offset="92" id="23215" /> <!--Horos Bangles +2-->
-        <item offset="93" id="23282" /> <!--Horos Tights +2-->
-        <item offset="94" id="23349" /> <!--Horos T. Shoes +2-->
-        <item offset="95" id="23082" /> <!--Peda. M.Board +2-->
-        <item offset="96" id="23149" /> <!--Peda. Gown +2-->
-        <item offset="97" id="23216" /> <!--Peda. Bracers +2-->
-        <item offset="98" id="23283" /> <!--Peda. Pants +2-->
-        <item offset="99" id="23350" /> <!--Peda. Loafers +2-->
-        <item offset="100" id="23083" /> <!--Bagua Galero +2-->
-        <item offset="101" id="23150" /> <!--Bagua Tunic +2-->
-        <item offset="102" id="23217" /> <!--Bagua Mitaines +2-->
-        <item offset="103" id="23284" /> <!--Bagua Pants +2-->
-        <item offset="104" id="23351" /> <!--Bagua Sandals +2-->
-        <item offset="105" id="23084" /> <!--Fu. Bandeau +2-->
-        <item offset="106" id="23151" /> <!--Futhark Coat +2-->
-        <item offset="107" id="23218" /> <!--Futhark Mitons +2-->
-        <item offset="108" id="23285" /> <!--Futhark Trousers +2-->
-        <item offset="109" id="23352" /> <!--Futhark Boots +2-->
-    </slip>
-    <slip id="29338">
-        <item offset="0" id="23398" /> <!--Agoge Mask +3-->
-        <item offset="1" id="23465" /> <!--Agoge Lorica +3-->
-        <item offset="2" id="23532" /> <!--Agoge Mufflers +3-->
-        <item offset="3" id="23599" /> <!--Agoge Cuisses +3-->
-        <item offset="4" id="23666" /> <!--Agoge Calligae +3-->
-        <item offset="5" id="23399" /> <!--Hes. Crown +3-->
-        <item offset="6" id="23466" /> <!--Hes. Cyclas +3-->
-        <item offset="7" id="23533" /> <!--Hes. Gloves +3-->
-        <item offset="8" id="23600" /> <!--Hes. Hose +3-->
-        <item offset="9" id="23667" /> <!--Hes. Gaiters +3-->
-        <item offset="10" id="23400" /> <!--Piety Cap +3-->
-        <item offset="11" id="23467" /> <!--Piety Bliaut +3-->
-        <item offset="12" id="23534" /> <!--Piety Mitts +3-->
-        <item offset="13" id="23601" /> <!--Piety Pantaln. +3-->
-        <item offset="14" id="23668" /> <!--Piety Duckbills +3-->
-        <item offset="15" id="23401" /> <!--Arch. Petasos +3-->
-        <item offset="16" id="23468" /> <!--Arch. Coat +3-->
-        <item offset="17" id="23535" /> <!--Arch. Gloves +3-->
-        <item offset="18" id="23602" /> <!--Arch. Tonban +3-->
-        <item offset="19" id="23669" /> <!--Arch. Sabots +3-->
-        <item offset="20" id="23402" /> <!--Viti. Chapeau +3-->
-        <item offset="21" id="23469" /> <!--Viti. Tabard +3-->
-        <item offset="22" id="23536" /> <!--Viti. Gloves +3-->
-        <item offset="23" id="23603" /> <!--Viti. Tights +3-->
-        <item offset="24" id="23670" /> <!--Vitiation Boots +3-->
-        <item offset="25" id="23403" /> <!--Plun. Bonnet +3-->
-        <item offset="26" id="23470" /> <!--Plunderer's Vest +3-->
-        <item offset="27" id="23537" /> <!--Plun. Armlets +3-->
-        <item offset="28" id="23604" /> <!--Plun. Culottes +3-->
-        <item offset="29" id="23671" /> <!--Plun. Poulaines +3-->
-        <item offset="30" id="23404" /> <!--Cab. Coronet +3-->
-        <item offset="31" id="23471" /> <!--Cab. Surcoat +3-->
-        <item offset="32" id="23538" /> <!--Cab. Gauntlets +3-->
-        <item offset="33" id="23605" /> <!--Cab. Breeches +3-->
-        <item offset="34" id="23672" /> <!--Cab. Leggings +3-->
-        <item offset="35" id="23405" /> <!--Fall. Burgeonet +3-->
-        <item offset="36" id="23472" /> <!--Fall. Cuirass +3-->
-        <item offset="37" id="23539" /> <!--Fall. Fin. Gaunt. +3-->
-        <item offset="38" id="23606" /> <!--Fall. Flanchard +3-->
-        <item offset="39" id="23673" /> <!--Fall. Sollerets +3-->
-        <item offset="40" id="23406" /> <!--Ankusa Helm +3-->
-        <item offset="41" id="23473" /> <!--An. Jackcoat +3-->
-        <item offset="42" id="23540" /> <!--Ankusa Gloves +3-->
-        <item offset="43" id="23607" /> <!--Ankusa Trousers +3-->
-        <item offset="44" id="23674" /> <!--Ankusa Gaiters +3-->
-        <item offset="45" id="23407" /> <!--Bihu Roundlet +3-->
-        <item offset="46" id="23474" /> <!--Bihu Jstcorps. +3-->
-        <item offset="47" id="23541" /> <!--Bihu Cuffs +3-->
-        <item offset="48" id="23608" /> <!--Bihu Cannions +3-->
-        <item offset="49" id="23675" /> <!--Bihu Slippers +3-->
-        <item offset="50" id="23408" /> <!--Arcadian Beret +3-->
-        <item offset="51" id="23475" /> <!--Arc. Jerkin +3-->
-        <item offset="52" id="23542" /> <!--Arc. Bracers +3-->
-        <item offset="53" id="23609" /> <!--Arc. Braccae +3-->
-        <item offset="54" id="23676" /> <!--Arcadian Socks +3-->
-        <item offset="55" id="23409" /> <!--Sakonji Kabuto +3-->
-        <item offset="56" id="23476" /> <!--Sakonji Domaru +3-->
-        <item offset="57" id="23543" /> <!--Sakonji Kote +3-->
-        <item offset="58" id="23610" /> <!--Sakonji Haidate +3-->
-        <item offset="59" id="23677" /> <!--Sak. Sune-Ate +3-->
-        <item offset="60" id="23410" /> <!--Mochi. Hatsuburi +3-->
-        <item offset="61" id="23477" /> <!--Mochi. Chainmail +3-->
-        <item offset="62" id="23544" /> <!--Mochizuki Tekko +3-->
-        <item offset="63" id="23611" /> <!--Mochi. Hakama +3-->
-        <item offset="64" id="23678" /> <!--Mochi. Kyahan +3-->
-        <item offset="65" id="23411" /> <!--Ptero. Armet +3-->
-        <item offset="66" id="23478" /> <!--Ptero. Mail +3-->
-        <item offset="67" id="23545" /> <!--Ptero. Fin. G. +3-->
-        <item offset="68" id="23612" /> <!--Ptero. Brais +3-->
-        <item offset="69" id="23679" /> <!--Ptero. Greaves +3-->
-        <item offset="70" id="23412" /> <!--Glyphic Horn +3-->
-        <item offset="71" id="23479" /> <!--Glyphic Doublet +3-->
-        <item offset="72" id="23546" /> <!--Glyphic Bracers +3-->
-        <item offset="73" id="23613" /> <!--Glyphic Spats +3-->
-        <item offset="74" id="23680" /> <!--Glyph. Pigaches +3-->
-        <item offset="75" id="23413" /> <!--Luh. Keffiyeh +3-->
-        <item offset="76" id="23480" /> <!--Luhlaza Jubbah +3-->
-        <item offset="77" id="23547" /> <!--Luh. Bazubands +3-->
-        <item offset="78" id="23614" /> <!--Luhlaza Shalwar +3-->
-        <item offset="79" id="23681" /> <!--Luhlaza Charuqs +3-->
-        <item offset="80" id="23414" /> <!--Lanun Tricorne +3-->
-        <item offset="81" id="23481" /> <!--Lanun Frac +3-->
-        <item offset="82" id="23548" /> <!--Lanun Gants +3-->
-        <item offset="83" id="23615" /> <!--Lanun Trews +3-->
-        <item offset="84" id="23682" /> <!--Lanun Bottes +3-->
-        <item offset="85" id="23415" /> <!--Pitre Taj +3-->
-        <item offset="86" id="23482" /> <!--Pitre Tobe +3-->
-        <item offset="87" id="23549" /> <!--Pitre Dastanas +3-->
-        <item offset="88" id="23616" /> <!--Pitre Churidars +3-->
-        <item offset="89" id="23683" /> <!--Pitre Babouches +3-->
-        <item offset="90" id="23416" /> <!--Horos Tiara +3-->
-        <item offset="91" id="23483" /> <!--Horos Casaque +3-->
-        <item offset="92" id="23550" /> <!--Horos Bangles +3-->
-        <item offset="93" id="23617" /> <!--Horos Tights +3-->
-        <item offset="94" id="23684" /> <!--Horos T. Shoes +3-->
-        <item offset="95" id="23417" /> <!--Peda. M.Board +3-->
-        <item offset="96" id="23484" /> <!--Peda. Gown +3-->
-        <item offset="97" id="23551" /> <!--Peda. Bracers +3-->
-        <item offset="98" id="23618" /> <!--Peda. Pants +3-->
-        <item offset="99" id="23685" /> <!--Peda. Loafers +3-->
-        <item offset="100" id="23418" /> <!--Bagua Galero +3-->
-        <item offset="101" id="23485" /> <!--Bagua Tunic +3-->
-        <item offset="102" id="23552" /> <!--Bagua Mitaines +3-->
-        <item offset="103" id="23619" /> <!--Bagua Pants +3-->
-        <item offset="104" id="23686" /> <!--Bagua Sandals +3-->
-        <item offset="105" id="23419" /> <!--Fu. Bandeau +3-->
-        <item offset="106" id="23486" /> <!--Futhark Coat +3-->
-        <item offset="107" id="23553" /> <!--Futhark Mitons +3-->
-        <item offset="108" id="23620" /> <!--Futhark Trousers +3-->
-        <item offset="109" id="23687" /> <!--Futhark Boots +3-->
-    </slip>
-    <slip id="29339">
-        <item offset="0" id="21515" /> <!--Tokko Knuckles-->
-        <item offset="1" id="21561" /> <!--Tokko Knife-->
-        <item offset="2" id="21617" /> <!--Tokko Sword-->
-        <item offset="3" id="21670" /> <!--Tokko Claymore-->
-        <item offset="4" id="21718" /> <!--Tokko Axe-->
-        <item offset="5" id="21775" /> <!--Tokko Chopper-->
-        <item offset="6" id="21826" /> <!--Tokko Scythe-->
-        <item offset="7" id="21879" /> <!--Tokko Lance-->
-        <item offset="8" id="21918" /> <!--Tokko Katana-->
-        <item offset="9" id="21971" /> <!--Tokko Tachi-->
-        <item offset="10" id="22027" /> <!--Tokko Rod-->
-        <item offset="11" id="22082" /> <!--Tokko Staff-->
-        <item offset="12" id="22108" /> <!--Tokko Bow-->
-        <item offset="13" id="22214" /> <!--Tokko Grip-->
-        <item offset="14" id="21516" /> <!--Ajja Knuckles-->
-        <item offset="15" id="21562" /> <!--Ajja Knife-->
-        <item offset="16" id="21618" /> <!--Ajja Sword-->
-        <item offset="17" id="21671" /> <!--Ajja Claymore-->
-        <item offset="18" id="21719" /> <!--Ajja Axe-->
-        <item offset="19" id="21776" /> <!--Ajja Chopper-->
-        <item offset="20" id="21827" /> <!--Ajja Scythe-->
-        <item offset="21" id="21880" /> <!--Ajja Lance-->
-        <item offset="22" id="21919" /> <!--Ajja Katana-->
-        <item offset="23" id="21972" /> <!--Ajja Tachi-->
-        <item offset="24" id="22028" /> <!--Ajja Rod-->
-        <item offset="25" id="22083" /> <!--Ajja Staff-->
-        <item offset="26" id="22109" /> <!--Ajja Bow-->
-        <item offset="27" id="22215" /> <!--Ajja Grip-->
-        <item offset="28" id="21517" /> <!--Eletta Knuckles-->
-        <item offset="29" id="21563" /> <!--Eletta Knife-->
-        <item offset="30" id="21619" /> <!--Eletta Sword-->
-        <item offset="31" id="21672" /> <!--Eletta Claymore-->
-        <item offset="32" id="21720" /> <!--Eletta Axe-->
-        <item offset="33" id="21777" /> <!--Eletta Chopper-->
-        <item offset="34" id="21828" /> <!--Eletta Scythe-->
-        <item offset="35" id="21881" /> <!--Eletta Lance-->
-        <item offset="36" id="21920" /> <!--Eletta Katana-->
-        <item offset="37" id="21973" /> <!--Eletta Tachi-->
-        <item offset="38" id="22029" /> <!--Eletta Rod-->
-        <item offset="39" id="22084" /> <!--Eletta Staff-->
-        <item offset="40" id="22110" /> <!--Eletta Bow-->
-        <item offset="41" id="22216" /> <!--Eletta Grip-->
-        <item offset="42" id="21518" /> <!--Kaja Knuckles-->
-        <item offset="43" id="21564" /> <!--Kaja Knife-->
-        <item offset="44" id="21620" /> <!--Kaja Sword-->
-        <item offset="45" id="21673" /> <!--Kaja Claymore-->
-        <item offset="46" id="21721" /> <!--Kaja Axe-->
-        <item offset="47" id="21778" /> <!--Kaja Chopper-->
-        <item offset="48" id="21829" /> <!--Kaja Scythe-->
-        <item offset="49" id="21882" /> <!--Kaja Lance-->
-        <item offset="50" id="21921" /> <!--Kaja Katana-->
-        <item offset="51" id="21974" /> <!--Kaja Tachi-->
-        <item offset="52" id="22030" /> <!--Kaja Rod-->
-        <item offset="53" id="22085" /> <!--Kaja Staff-->
-        <item offset="54" id="22111" /> <!--Kaja Bow-->
-        <item offset="55" id="22217" /> <!--Kaja Grip-->
-        <item offset="56" id="21519" /> <!--Karambit-->
-        <item offset="57" id="21565" /> <!--Tauret-->
-        <item offset="58" id="21621" /> <!--Naegling-->
-        <item offset="59" id="21674" /> <!--Nandaka-->
-        <item offset="60" id="21722" /> <!--Dolichenus-->
-        <item offset="61" id="21779" /> <!--Lycurgos-->
-        <item offset="62" id="21830" /> <!--Drepanum-->
-        <item offset="63" id="21883" /> <!--Shining One-->
-        <item offset="64" id="21922" /> <!--Gokotai-->
-        <item offset="65" id="21975" /> <!--Hachimonji-->
-        <item offset="66" id="22031" /> <!--Maxentius-->
-        <item offset="67" id="22086" /> <!--Xoanon-->
-        <item offset="68" id="22107" /> <!--Ullr-->
-        <item offset="69" id="22218" /> <!--Khonsu-->
-        <item offset="70" id="22089" /> <!--Sophistry-->
-    </slip>
-    <slip id="29340">
-        <item offset="0" id="23085" /> <!--Boii Mask +2-->
-        <item offset="1" id="23152" /> <!--Boii Lorica +2-->
-        <item offset="2" id="23219" /> <!--Boii Mufflers +2-->
-        <item offset="3" id="23286" /> <!--Boii Cuisses +2-->
-        <item offset="4" id="23353" /> <!--Boii Calligae +2-->
-        <item offset="5" id="23086" /> <!--Bhikku Crown +2-->
-        <item offset="6" id="23153" /> <!--Bhikku Cyclas +2-->
-        <item offset="7" id="23220" /> <!--Bhikku Gloves +2-->
-        <item offset="8" id="23287" /> <!--Bhikku Hose +2-->
-        <item offset="9" id="23354" /> <!--Bhikku Gaiters +2-->
-        <item offset="10" id="23087" /> <!--Ebers Cap +2-->
-        <item offset="11" id="23154" /> <!--Ebers Bliaut +2-->
-        <item offset="12" id="23221" /> <!--Ebers Mitts +2-->
-        <item offset="13" id="23288" /> <!--Ebers Pant. +2-->
-        <item offset="14" id="23355" /> <!--Ebers Duckbills +2-->
-        <item offset="15" id="23088" /> <!--Wicce Petasos +2-->
-        <item offset="16" id="23155" /> <!--Wicce Coat +2-->
-        <item offset="17" id="23222" /> <!--Wicce Gloves +2-->
-        <item offset="18" id="23289" /> <!--Wicce Chausses +2-->
-        <item offset="19" id="23356" /> <!--Wicce Sabots +2-->
-        <item offset="20" id="23089" /> <!--Leth. Chappel +2-->
-        <item offset="21" id="23156" /> <!--Lethargy Sayon +2-->
-        <item offset="22" id="23223" /> <!--Leth. Ganth. +2-->
-        <item offset="23" id="23290" /> <!--Leth. Fuseau +2-->
-        <item offset="24" id="23357" /> <!--Leth. Houseaux +2-->
-        <item offset="25" id="23090" /> <!--Skulker's Bonnet +2-->
-        <item offset="26" id="23157" /> <!--Skulker's Vest +2-->
-        <item offset="27" id="23224" /> <!--Skulk. Armlets +2-->
-        <item offset="28" id="23291" /> <!--Skulk. Culottes +2-->
-        <item offset="29" id="23358" /> <!--Skulk. Poulaines +2-->
-        <item offset="30" id="23091" /> <!--Chev. Armet +2-->
-        <item offset="31" id="23158" /> <!--Chev. Cuirass +2-->
-        <item offset="32" id="23225" /> <!--Chev. Gauntlets +2-->
-        <item offset="33" id="23292" /> <!--Chev. Cuisses +2-->
-        <item offset="34" id="23359" /> <!--Chev. Sabatons +2-->
-        <item offset="35" id="23092" /> <!--Heath. Burgeon. +2-->
-        <item offset="36" id="23159" /> <!--Heath. Cuirass +2-->
-        <item offset="37" id="23226" /> <!--Heath. Gauntlets +2-->
-        <item offset="38" id="23293" /> <!--Heath. Flanchard +2-->
-        <item offset="39" id="23360" /> <!--Heath. Sollerets +2-->
-        <item offset="40" id="23093" /> <!--Nuk. Cabasset +2-->
-        <item offset="41" id="23160" /> <!--Nukumi Gausape +2-->
-        <item offset="42" id="23227" /> <!--Nukumi Manoplas +2-->
-        <item offset="43" id="23294" /> <!--Nukumi Quijotes +2-->
-        <item offset="44" id="23361" /> <!--Nukumi Ocreae +2-->
-        <item offset="45" id="23094" /> <!--Fili Calot +2-->
-        <item offset="46" id="23161" /> <!--Fili Hongreline +2-->
-        <item offset="47" id="23228" /> <!--Fili Manchettes +2-->
-        <item offset="48" id="23295" /> <!--Fili Rhingrave +2-->
-        <item offset="49" id="23362" /> <!--Fili Cothurnes +2-->
-        <item offset="50" id="23095" /> <!--Amini Gapette +2-->
-        <item offset="51" id="23162" /> <!--Amini Caban +2-->
-        <item offset="52" id="23229" /> <!--Amini Glove. +2-->
-        <item offset="53" id="23296" /> <!--Amini Bragues +2-->
-        <item offset="54" id="23363" /> <!--Amini Bottillons +2-->
-        <item offset="55" id="23096" /> <!--Kasuga Kabuto +2-->
-        <item offset="56" id="23163" /> <!--Kasuga Domaru +2-->
-        <item offset="57" id="23230" /> <!--Kasuga Kote +2-->
-        <item offset="58" id="23297" /> <!--Kasuga Haidate +2-->
-        <item offset="59" id="23364" /> <!--Kas. Sune-Ate +2-->
-        <item offset="60" id="23097" /> <!--Hattori Zukin +2-->
-        <item offset="61" id="23164" /> <!--Hattori Ningi +2-->
-        <item offset="62" id="23231" /> <!--Hattori Tekko +2-->
-        <item offset="63" id="23298" /> <!--Hattori Hakama +2-->
-        <item offset="64" id="23365" /> <!--Hattori Kyahan +2-->
-        <item offset="65" id="23098" /> <!--Peltast's Mezail +2-->
-        <item offset="66" id="23165" /> <!--Pelt. Plackart +2-->
-        <item offset="67" id="23232" /> <!--Pel. Vambraces +2-->
-        <item offset="68" id="23299" /> <!--Pelt. Cuissots +2-->
-        <item offset="69" id="23366" /> <!--Pelt. Schyn. +2-->
-        <item offset="70" id="23099" /> <!--Beckoner's Horn +2-->
-        <item offset="71" id="23166" /> <!--Beck. Doublet +2-->
-        <item offset="72" id="23233" /> <!--Beck. Bracers +2-->
-        <item offset="73" id="23300" /> <!--Beck. Spats +2-->
-        <item offset="74" id="23367" /> <!--Beck. Pigaches +2-->
-        <item offset="75" id="23100" /> <!--Hashishin Kavuk +2-->
-        <item offset="76" id="23167" /> <!--Hashishin Mintan +2-->
-        <item offset="77" id="23234" /> <!--Hashi. Bazu. +2-->
-        <item offset="78" id="23301" /> <!--Hashishin Tayt +2-->
-        <item offset="79" id="23368" /> <!--Hashi. Basmak +2-->
-        <item offset="80" id="23101" /> <!--Chass. Tricorne +2-->
-        <item offset="81" id="23168" /> <!--Chasseur's Frac +2-->
-        <item offset="82" id="23235" /> <!--Chasseur's Gants +2-->
-        <item offset="83" id="23302" /> <!--Chas. Culottes +2-->
-        <item offset="84" id="23369" /> <!--Chass. Bottes +2-->
-        <item offset="85" id="23102" /> <!--Kara. Cappello +2-->
-        <item offset="86" id="23169" /> <!--Kara. Farsetto +2-->
-        <item offset="87" id="23236" /> <!--Karagoz Guanti +2-->
-        <item offset="88" id="23303" /> <!--Kara. Pantaloni +2-->
-        <item offset="89" id="23370" /> <!--Karagoz Scarpe +2-->
-        <item offset="90" id="23103" /> <!--Maculele Tiara +2-->
-        <item offset="91" id="23170" /> <!--Macu. Casaque +2-->
-        <item offset="92" id="23237" /> <!--Macu. Bangles +2-->
-        <item offset="93" id="23304" /> <!--Maculele Tights +2-->
-        <item offset="94" id="23371" /> <!--Macu. Toe Sh. +2-->
-        <item offset="95" id="23104" /> <!--Arbatel Bonnet +2-->
-        <item offset="96" id="23171" /> <!--Arbatel Gown +2-->
-        <item offset="97" id="23238" /> <!--Arbatel Bracers +2-->
-        <item offset="98" id="23305" /> <!--Arbatel Pants +2-->
-        <item offset="99" id="23372" /> <!--Arbatel Loafers +2-->
-        <item offset="100" id="23105" /> <!--Azimuth Hood +2-->
-        <item offset="101" id="23172" /> <!--Azimuth Coat +2-->
-        <item offset="102" id="23239" /> <!--Azimuth Gloves +2-->
-        <item offset="103" id="23306" /> <!--Azimuth Tights +2-->
-        <item offset="104" id="23373" /> <!--Azimuth Gaiters +2-->
-        <item offset="105" id="23106" /> <!--Erilaz Galea +2-->
-        <item offset="106" id="23173" /> <!--Erilaz Surcoat +2-->
-        <item offset="107" id="23240" /> <!--Erilaz Gauntlets +2-->
-        <item offset="108" id="23307" /> <!--Eri. Leg Guards +2-->
-        <item offset="109" id="23374" /> <!--Erilaz Greaves +2-->
-    </slip>
-    <slip id="29341">
-        <item offset="0" id="23420" /> <!--Boii Mask +3-->
-        <item offset="1" id="23487" /> <!--Boii Lorica +3-->
-        <item offset="2" id="23554" /> <!--Boii Mufflers +3-->
-        <item offset="3" id="23621" /> <!--Boii Cuisses +3-->
-        <item offset="4" id="23688" /> <!--Boii Calligae +3-->
-        <item offset="5" id="23421" /> <!--Bhikku Crown +3-->
-        <item offset="6" id="23488" /> <!--Bhikku Cyclas +3-->
-        <item offset="7" id="23555" /> <!--Bhikku Gloves +3-->
-        <item offset="8" id="23622" /> <!--Bhikku Hose +3-->
-        <item offset="9" id="23689" /> <!--Bhikku Gaiters +3-->
-        <item offset="10" id="23422" /> <!--Ebers Cap +3-->
-        <item offset="11" id="23489" /> <!--Ebers Bliaut +3-->
-        <item offset="12" id="23556" /> <!--Ebers Mitts +3-->
-        <item offset="13" id="23623" /> <!--Ebers Pant. +3-->
-        <item offset="14" id="23690" /> <!--Ebers Duckbills +3-->
-        <item offset="15" id="23423" /> <!--Wicce Petasos +3-->
-        <item offset="16" id="23490" /> <!--Wicce Coat +3-->
-        <item offset="17" id="23557" /> <!--Wicce Gloves +3-->
-        <item offset="18" id="23624" /> <!--Wicce Chausses +3-->
-        <item offset="19" id="23691" /> <!--Wicce Sabots +3-->
-        <item offset="20" id="23424" /> <!--Leth. Chappel +3-->
-        <item offset="21" id="23491" /> <!--Lethargy Sayon +3-->
-        <item offset="22" id="23558" /> <!--Leth. Ganth. +3-->
-        <item offset="23" id="23625" /> <!--Leth. Fuseau +3-->
-        <item offset="24" id="23692" /> <!--Leth. Houseaux +3-->
-        <item offset="25" id="23425" /> <!--Skulker's Bonnet +3-->
-        <item offset="26" id="23492" /> <!--Skulker's Vest +3-->
-        <item offset="27" id="23559" /> <!--Skulk. Armlets +3-->
-        <item offset="28" id="23626" /> <!--Skulk. Culottes +3-->
-        <item offset="29" id="23693" /> <!--Skulk. Poulaines +3-->
-        <item offset="30" id="23426" /> <!--Chev. Armet +3-->
-        <item offset="31" id="23493" /> <!--Chev. Cuirass +3-->
-        <item offset="32" id="23560" /> <!--Chev. Gauntlets +3-->
-        <item offset="33" id="23627" /> <!--Chev. Cuisses +3-->
-        <item offset="34" id="23694" /> <!--Chev. Sabatons +3-->
-        <item offset="35" id="23427" /> <!--Heath. Bur. +3-->
-        <item offset="36" id="23494" /> <!--Heath. Cuirass +3-->
-        <item offset="37" id="23561" /> <!--Heath. Gauntlets +3-->
-        <item offset="38" id="23628" /> <!--Heath. Flanchard +3-->
-        <item offset="39" id="23695" /> <!--Heath. Sollerets +3-->
-        <item offset="40" id="23428" /> <!--Nuk. Cabasset +3-->
-        <item offset="41" id="23495" /> <!--Nukumi Gausape +3-->
-        <item offset="42" id="23562" /> <!--Nukumi Manoplas +3-->
-        <item offset="43" id="23629" /> <!--Nukumi Quijotes +3-->
-        <item offset="44" id="23696" /> <!--Nukumi Ocreae +3-->
-        <item offset="45" id="23429" /> <!--Fili Calot +3-->
-        <item offset="46" id="23496" /> <!--Fili Hongreline +3-->
-        <item offset="47" id="23563" /> <!--Fili Manchettes +3-->
-        <item offset="48" id="23630" /> <!--Fili Rhingrave +3-->
-        <item offset="49" id="23697" /> <!--Fili Cothurnes +3-->
-        <item offset="50" id="23430" /> <!--Amini Gapette +3-->
-        <item offset="51" id="23497" /> <!--Amini Caban +3-->
-        <item offset="52" id="23564" /> <!--Amini Glove. +3-->
-        <item offset="53" id="23631" /> <!--Amini Bragues +3-->
-        <item offset="54" id="23698" /> <!--Amini Bottillons +3-->
-        <item offset="55" id="23431" /> <!--Kasuga Kabuto +3-->
-        <item offset="56" id="23498" /> <!--Kasuga Domaru +3-->
-        <item offset="57" id="23565" /> <!--Kasuga Kote +3-->
-        <item offset="58" id="23632" /> <!--Kasuga Haidate +3-->
-        <item offset="59" id="23699" /> <!--Kas. Sune-Ate +3-->
-        <item offset="60" id="23432" /> <!--Hattori Zukin +3-->
-        <item offset="61" id="23499" /> <!--Hattori Ningi +3-->
-        <item offset="62" id="23566" /> <!--Hattori Tekko +3-->
-        <item offset="63" id="23633" /> <!--Hattori Hakama +3-->
-        <item offset="64" id="23700" /> <!--Hattori Kyahan +3-->
-        <item offset="65" id="23433" /> <!--Peltast's Mezail +3-->
-        <item offset="66" id="23500" /> <!--Pelt. Plackart +3-->
-        <item offset="67" id="23567" /> <!--Pel. Vambraces +3-->
-        <item offset="68" id="23634" /> <!--Pelt. Cuissots +3-->
-        <item offset="69" id="23701" /> <!--Pelt. Schyn. +3-->
-        <item offset="70" id="23434" /> <!--Beckoner's Horn +3-->
-        <item offset="71" id="23501" /> <!--Beck. Doublet +3-->
-        <item offset="72" id="23568" /> <!--Beck. Bracers +3-->
-        <item offset="73" id="23635" /> <!--Beck. Spats +3-->
-        <item offset="74" id="23702" /> <!--Beck. Pigaches +3-->
-        <item offset="75" id="23435" /> <!--Hashishin Kavuk +3-->
-        <item offset="76" id="23502" /> <!--Hashishin Mintan +3-->
-        <item offset="77" id="23569" /> <!--Hashi. Bazu. +3-->
-        <item offset="78" id="23636" /> <!--Hashishin Tayt +3-->
-        <item offset="79" id="23703" /> <!--Hashi. Basmak +3-->
-        <item offset="80" id="23436" /> <!--Chass. Tricorne +3-->
-        <item offset="81" id="23503" /> <!--Chasseur's Frac +3-->
-        <item offset="82" id="23570" /> <!--Chasseur's Gants +3-->
-        <item offset="83" id="23637" /> <!--Chas. Culottes +3-->
-        <item offset="84" id="23704" /> <!--Chass. Bottes +3-->
-        <item offset="85" id="23437" /> <!--Kara. Cappello +3-->
-        <item offset="86" id="23504" /> <!--Kara. Farsetto +3-->
-        <item offset="87" id="23571" /> <!--Karagoz Guanti +3-->
-        <item offset="88" id="23638" /> <!--Kara. Pantaloni +3-->
-        <item offset="89" id="23705" /> <!--Karagoz Scarpe +3-->
-        <item offset="90" id="23438" /> <!--Maculele Tiara +3-->
-        <item offset="91" id="23505" /> <!--Macu. Casaque +3-->
-        <item offset="92" id="23572" /> <!--Macu. Bangles +3-->
-        <item offset="93" id="23639" /> <!--Maculele Tights +3-->
-        <item offset="94" id="23706" /> <!--Macu. Toe Sh. +3-->
-        <item offset="95" id="23439" /> <!--Arbatel Bonnet +3-->
-        <item offset="96" id="23506" /> <!--Arbatel Gown +3-->
-        <item offset="97" id="23573" /> <!--Arbatel Bracers +3-->
-        <item offset="98" id="23640" /> <!--Arbatel Pants +3-->
-        <item offset="99" id="23707" /> <!--Arbatel Loafers +3-->
-        <item offset="100" id="23440" /> <!--Azimuth Hood +3-->
-        <item offset="101" id="23507" /> <!--Azimuth Coat +3-->
-        <item offset="102" id="23574" /> <!--Azimuth Gloves +3-->
-        <item offset="103" id="23641" /> <!--Azimuth Tights +3-->
-        <item offset="104" id="23708" /> <!--Azimuth Gaiters +3-->
-        <item offset="105" id="23441" /> <!--Erilaz Galea +3-->
-        <item offset="106" id="23508" /> <!--Erilaz Surcoat +3-->
-        <item offset="107" id="23575" /> <!--Erilaz Gauntlets +3-->
-        <item offset="108" id="23642" /> <!--Eri. Leg Guards +3-->
-        <item offset="109" id="23709" /> <!--Erilaz Greaves +3-->
-    </slip>
-    <slip id="29342">
-        <item offset="0" id="23812" /> <!--Sapphire Mask-->
-        <item offset="1" id="23813" /> <!--Sapphire Platemail-->
-        <item offset="2" id="23814" /> <!--Sapphire Gauntlets-->
-        <item offset="3" id="23815" /> <!--Sapphire Trousers-->
-        <item offset="4" id="23816" /> <!--Sapphire Leggings-->
-        <item offset="5" id="23817" /> <!--Jadeite Visor-->
-        <item offset="6" id="23818" /> <!--Jadeite Cuirie-->
-        <item offset="7" id="23819" /> <!--Jadeite Gloves-->
-        <item offset="8" id="23820" /> <!--Jadeite Chausses-->
-        <item offset="9" id="23821" /> <!--Jadeite Jambeaux-->
-        <item offset="10" id="23832" /> <!--Ruby Coronal-->
-        <item offset="11" id="23833" /> <!--Ruby Robe-->
-        <item offset="12" id="23834" /> <!--Ruby Cuffs-->
-        <item offset="13" id="23835" /> <!--Ruby Slops-->
-        <item offset="14" id="23836" /> <!--Ruby Pigaches-->
-    </slip>
+	<slip id="29312">		<!--Storage Slip 01-->
+		<item offset="0" id="16084" />	<!--Ares' Mask-->
+		<item offset="1" id="14546" />	<!--Ares' Cuirass-->
+		<item offset="2" id="14961" />	<!--Ares' Gauntlets-->
+		<item offset="3" id="15625" />	<!--Ares' Flanchard-->
+		<item offset="4" id="15711" />	<!--Ares' Sollerets-->
+		<item offset="5" id="16085" />	<!--Enyo's Mask-->
+		<item offset="6" id="14547" />	<!--Enyo's Brstplate-->
+		<item offset="7" id="14962" />	<!--Enyo's Gauntlets-->
+		<item offset="8" id="15626" />	<!--Enyo's Cuisses-->
+		<item offset="9" id="15712" />	<!--Enyo's Leggings-->
+		<item offset="10" id="16086" />	<!--Phobos's Mask-->
+		<item offset="11" id="14548" />	<!--Phobos's Cuirass-->
+		<item offset="12" id="14963" />	<!--Phobos's Gnt.-->
+		<item offset="13" id="15627" />	<!--Phobos's Cuisses-->
+		<item offset="14" id="15713" />	<!--Phobos's Sabat.-->
+		<item offset="15" id="16087" />	<!--Deimos's Mask-->
+		<item offset="16" id="14549" />	<!--Deimos's Cuirass-->
+		<item offset="17" id="14964" />	<!--Deimos's Gnt.-->
+		<item offset="18" id="15628" />	<!--Deimos's Cuisses-->
+		<item offset="19" id="15714" />	<!--Deimos's Leggings-->
+		<item offset="20" id="16088" />	<!--Skadi's Visor-->
+		<item offset="21" id="14550" />	<!--Skadi's Cuirie-->
+		<item offset="22" id="14965" />	<!--Skadi's Bazubands-->
+		<item offset="23" id="15629" />	<!--Skadi's Chausses-->
+		<item offset="24" id="15715" />	<!--Skadi's Jambeaux-->
+		<item offset="25" id="16089" />	<!--Njord's Mask-->
+		<item offset="26" id="14551" />	<!--Njord's Jerkin-->
+		<item offset="27" id="14966" />	<!--Njord's Gloves-->
+		<item offset="28" id="15630" />	<!--Njord's Trousers-->
+		<item offset="29" id="15716" />	<!--Njord's Ledelsens-->
+		<item offset="30" id="16090" />	<!--Freyr's Mask-->
+		<item offset="31" id="14552" />	<!--Freyr's Jerkin-->
+		<item offset="32" id="14967" />	<!--Freyr's Gloves-->
+		<item offset="33" id="15631" />	<!--Freyr's Trousers-->
+		<item offset="34" id="15717" />	<!--Freyr's Ledelsens-->
+		<item offset="35" id="16091" />	<!--Freya's Mask-->
+		<item offset="36" id="14553" />	<!--Freya's Jerkin-->
+		<item offset="37" id="14968" />	<!--Freya's Gloves-->
+		<item offset="38" id="15632" />	<!--Freya's Trousers-->
+		<item offset="39" id="15718" />	<!--Freya's Ledelsens-->
+		<item offset="40" id="16092" />	<!--Usukane Somen-->
+		<item offset="41" id="14554" />	<!--Usukane Haramaki-->
+		<item offset="42" id="14969" />	<!--Usukane Gote-->
+		<item offset="43" id="15633" />	<!--Usukane Hizayoroi-->
+		<item offset="44" id="15719" />	<!--Usukane Sune-Ate-->
+		<item offset="45" id="16093" />	<!--H.kazu Hachimaki-->
+		<item offset="46" id="14555" />	<!--Hoshikazu Gi-->
+		<item offset="47" id="14970" />	<!--Hoshikazu Tekko-->
+		<item offset="48" id="15634" />	<!--Hoshikazu Hakama-->
+		<item offset="49" id="15720" />	<!--H.kazu Kyahan-->
+		<item offset="50" id="16094" />	<!--T.kazu Jinpachi-->
+		<item offset="51" id="14556" />	<!--Tsukikazu Togi-->
+		<item offset="52" id="14971" />	<!--Tsukikazu Gote-->
+		<item offset="53" id="15635" />	<!--Tsukikazu Haidate-->
+		<item offset="54" id="15721" />	<!--T.kazu Sune-Ate-->
+		<item offset="55" id="16095" />	<!--Hikazu Kabuto-->
+		<item offset="56" id="14557" />	<!--Hikazu Hara-Ate-->
+		<item offset="57" id="14972" />	<!--Hikazu Gote-->
+		<item offset="58" id="15636" />	<!--Hikazu Hakama-->
+		<item offset="59" id="15722" />	<!--Hikazu Sune-Ate-->
+		<item offset="60" id="16096" />	<!--Marduk's Tiara-->
+		<item offset="61" id="14558" />	<!--Marduk's Jubbah-->
+		<item offset="62" id="14973" />	<!--Marduk's Dastanas-->
+		<item offset="63" id="15637" />	<!--Marduk's Shalwar-->
+		<item offset="64" id="15723" />	<!--Marduk's Crackows-->
+		<item offset="65" id="16097" />	<!--Anu's Tiara-->
+		<item offset="66" id="14559" />	<!--Anu's Doublet-->
+		<item offset="67" id="14974" />	<!--Anu's Gages-->
+		<item offset="68" id="15638" />	<!--Anu's Brais-->
+		<item offset="69" id="15724" />	<!--Anu's Gaiters-->
+		<item offset="70" id="16098" />	<!--Ea's Tiara-->
+		<item offset="71" id="14560" />	<!--Ea's Doublet-->
+		<item offset="72" id="14975" />	<!--Ea's Dastanas-->
+		<item offset="73" id="15639" />	<!--Ea's Brais-->
+		<item offset="74" id="15725" />	<!--Ea's Crackows-->
+		<item offset="75" id="16099" />	<!--Enlil's Tiara-->
+		<item offset="76" id="14561" />	<!--Enlil's Gambison-->
+		<item offset="77" id="14976" />	<!--Enlil's Kolluks-->
+		<item offset="78" id="15640" />	<!--Enlil's Brayettes-->
+		<item offset="79" id="15726" />	<!--Enlil's Crackows-->
+		<item offset="80" id="16100" />	<!--Morrigan's Coron.-->
+		<item offset="81" id="14562" />	<!--Morrigan's Robe-->
+		<item offset="82" id="14977" />	<!--Morrigan's Cuffs-->
+		<item offset="83" id="15641" />	<!--Morrigan's Slops-->
+		<item offset="84" id="15727" />	<!--Morrigan's Pgch.-->
+		<item offset="85" id="16101" />	<!--Nemain's Crown-->
+		<item offset="86" id="14563" />	<!--Nemain's Robe-->
+		<item offset="87" id="14978" />	<!--Nemain's Cuffs-->
+		<item offset="88" id="15642" />	<!--Nemain's Slops-->
+		<item offset="89" id="15728" />	<!--Nemain's Sabots-->
+		<item offset="90" id="16102" />	<!--Bodb's Crown-->
+		<item offset="91" id="14564" />	<!--Bodb's Robe-->
+		<item offset="92" id="14979" />	<!--Bodb's Cuffs-->
+		<item offset="93" id="15643" />	<!--Bodb's Slops-->
+		<item offset="94" id="15729" />	<!--Bodb's Pigaches-->
+		<item offset="95" id="16103" />	<!--Macha's Crown-->
+		<item offset="96" id="14565" />	<!--Macha's Coat-->
+		<item offset="97" id="14980" />	<!--Macha's Cuffs-->
+		<item offset="98" id="15644" />	<!--Macha's Slops-->
+		<item offset="99" id="15730" />	<!--Macha's Pigaches-->
+		<item offset="100" id="16106" />	<!--Askar Zucchetto-->
+		<item offset="101" id="14568" />	<!--Askar Korazin-->
+		<item offset="102" id="14983" />	<!--Askar Manopolas-->
+		<item offset="103" id="15647" />	<!--Askar Dirs-->
+		<item offset="104" id="15733" />	<!--Askar Gambieras-->
+		<item offset="105" id="16107" />	<!--Denali Bonnet-->
+		<item offset="106" id="14569" />	<!--Denali Jacket-->
+		<item offset="107" id="14984" />	<!--Denali Wristbands-->
+		<item offset="108" id="15648" />	<!--Denali Kecks-->
+		<item offset="109" id="15734" />	<!--Denali Gamashes-->
+		<item offset="110" id="16108" />	<!--Goliard Chapeau-->
+		<item offset="111" id="14570" />	<!--Goliard Saio-->
+		<item offset="112" id="14985" />	<!--Goliard Cuffs-->
+		<item offset="113" id="15649" />	<!--Goliard Trews-->
+		<item offset="114" id="15735" />	<!--Goliard Clogs-->
+		<item offset="115" id="16602" />	<!--Perdu Sword-->
+		<item offset="116" id="17741" />	<!--Perdu Hanger-->
+		<item offset="117" id="18425" />	<!--Perdu Blade-->
+		<item offset="118" id="18491" />	<!--Perdu Voulge-->
+		<item offset="119" id="18588" />	<!--Perdu Staff-->
+		<item offset="120" id="18717" />	<!--Perdu Bow-->
+		<item offset="121" id="18718" />	<!--Perdu Crossbow-->
+		<item offset="122" id="18850" />	<!--Perdu Wand-->
+		<item offset="123" id="18943" />	<!--Perdu Sickle-->
+		<item offset="124" id="16069" />	<!--Pln. Qalansuwa-->
+		<item offset="125" id="14530" />	<!--Pln. Khazagand-->
+		<item offset="126" id="14940" />	<!--Pln. Dastanas-->
+		<item offset="127" id="15609" />	<!--Pln. Seraweels-->
+		<item offset="128" id="15695" />	<!--Pln. Crackows-->
+		<item offset="129" id="16062" />	<!--Amir Puggaree-->
+		<item offset="130" id="14525" />	<!--Amir Korazin-->
+		<item offset="131" id="14933" />	<!--Amir Kolluks-->
+		<item offset="132" id="15604" />	<!--Amir Dirs-->
+		<item offset="133" id="15688" />	<!--Amir Boots-->
+		<item offset="134" id="16064" />	<!--Yigit Turban-->
+		<item offset="135" id="14527" />	<!--Yigit Gomlek-->
+		<item offset="136" id="14935" />	<!--Yigit Gages-->
+		<item offset="137" id="15606" />	<!--Yigit Seraweels-->
+		<item offset="138" id="15690" />	<!--Yigit Crackows-->
+		<item offset="139" id="18685" />	<!--Imperial Kaman-->
+		<item offset="140" id="18065" />	<!--Storm Zaghnal-->
+		<item offset="141" id="17851" />	<!--Storm Fife-->
+		<item offset="142" id="18686" />	<!--Imperial Gun-->
+		<item offset="143" id="18025" />	<!--Khanjar-->
+		<item offset="144" id="18435" />	<!--Hotarumaru-->
+		<item offset="145" id="18113" />	<!--Imperial Neza-->
+		<item offset="146" id="17951" />	<!--Storm Tabar-->
+		<item offset="147" id="17715" />	<!--Storm Tulwar-->
+		<item offset="148" id="18485" />	<!--Imperial Bhuj-->
+		<item offset="149" id="18408" />	<!--Yigit Bulawa-->
+		<item offset="150" id="18365" />	<!--Pahluwan Patas-->
+		<item offset="151" id="18583" />	<!--Imperial Pole-->
+		<item offset="152" id="18417" />	<!--Sayosamonji-->
+		<item offset="153" id="18388" />	<!--Doombringer-->
+		<item offset="154" id="16267" />	<!--Ritter Gorget-->
+		<item offset="155" id="16268" />	<!--Kubira Beads-->
+		<item offset="156" id="16269" />	<!--Morgana's Choker-->
+		<item offset="157" id="16228" />	<!--Aslan Cape-->
+		<item offset="158" id="16229" />	<!--Gleeman's Cape-->
+		<item offset="159" id="15911" />	<!--Buccaneer's Belt-->
+		<item offset="160" id="15799" />	<!--Iota Ring-->
+		<item offset="161" id="15800" />	<!--Omega Ring-->
+		<item offset="162" id="15990" />	<!--Delta Earring-->
+		<item offset="163" id="17745" />	<!--Hofud-->
+		<item offset="164" id="18121" />	<!--Valkyrie's Fork-->
+		<item offset="165" id="16117" />	<!--Valhalla Helm-->
+		<item offset="166" id="14577" />	<!--Valhalla Brstplate-->
+		<item offset="167" id="17857" />	<!--Animator +1-->
+	</slip>
+	<slip id="29313">		<!--Storage Slip 02-->
+		<item offset="0" id="12421" />	<!--Koenig Schaller-->
+		<item offset="1" id="12549" />	<!--Koenig Cuirass-->
+		<item offset="2" id="12677" />	<!--Kng. Handschuhs-->
+		<item offset="3" id="12805" />	<!--Koenig Diechlings-->
+		<item offset="4" id="12933" />	<!--Koenig Schuhs-->
+		<item offset="5" id="13911" />	<!--Kaiser Schaller-->
+		<item offset="6" id="14370" />	<!--Kaiser Cuirass-->
+		<item offset="7" id="14061" />	<!--Kaiser Handschuhs-->
+		<item offset="8" id="14283" />	<!--Kaiser Diechlings-->
+		<item offset="9" id="14163" />	<!--Kaiser Schuhs-->
+		<item offset="10" id="12429" />	<!--Adaman Celata-->
+		<item offset="11" id="12557" />	<!--Adaman Hauberk-->
+		<item offset="12" id="12685" />	<!--Adaman Mufflers-->
+		<item offset="13" id="12813" />	<!--Adaman Breeches-->
+		<item offset="14" id="12941" />	<!--Adaman Sollerets-->
+		<item offset="15" id="13924" />	<!--Armada Celata-->
+		<item offset="16" id="14371" />	<!--Armada Hauberk-->
+		<item offset="17" id="14816" />	<!--Armada Mufflers-->
+		<item offset="18" id="14296" />	<!--Armada Breeches-->
+		<item offset="19" id="14175" />	<!--Armada Sollerets-->
+		<item offset="20" id="13934" />	<!--Shr.Znr.Kabuto-->
+		<item offset="21" id="14387" />	<!--Shura Togi-->
+		<item offset="22" id="14821" />	<!--Shura Kote-->
+		<item offset="23" id="14303" />	<!--Shura Haidate-->
+		<item offset="24" id="14184" />	<!--Shura Sune-Ate-->
+		<item offset="25" id="13935" />	<!--Shr.Znr.Kabuto +1-->
+		<item offset="26" id="14388" />	<!--Shura Togi +1-->
+		<item offset="27" id="14822" />	<!--Shura Kote +1-->
+		<item offset="28" id="14304" />	<!--Shura Haidate +1-->
+		<item offset="29" id="14185" />	<!--Shr. Sune-Ate +1-->
+		<item offset="30" id="13876" />	<!--Zenith Crown-->
+		<item offset="31" id="13787" />	<!--Dalmatica-->
+		<item offset="32" id="14006" />	<!--Zenith Mitts-->
+		<item offset="33" id="14247" />	<!--Zenith Slacks-->
+		<item offset="34" id="14123" />	<!--Zenith Pumps-->
+		<item offset="35" id="13877" />	<!--Zenith Crown +1-->
+		<item offset="36" id="13788" />	<!--Dalmatica +1-->
+		<item offset="37" id="14007" />	<!--Zenith Mitts +1-->
+		<item offset="38" id="14248" />	<!--Zenith Slacks +1-->
+		<item offset="39" id="14124" />	<!--Zenith Pumps +1-->
+		<item offset="40" id="13908" />	<!--Crimson Mask-->
+		<item offset="41" id="14367" />	<!--Crm. Scale Mail-->
+		<item offset="42" id="14058" />	<!--Crimson Fng. Gnt.-->
+		<item offset="43" id="14280" />	<!--Crimson Cuisses-->
+		<item offset="44" id="14160" />	<!--Crimson Greaves-->
+		<item offset="45" id="13909" />	<!--Blood Mask-->
+		<item offset="46" id="14368" />	<!--Blood Scale Mail-->
+		<item offset="47" id="14059" />	<!--Blood Fng. Gnt.-->
+		<item offset="48" id="14281" />	<!--Blood Cuisses-->
+		<item offset="49" id="14161" />	<!--Blood Greaves-->
+		<item offset="50" id="16113" />	<!--Shadow Helm-->
+		<item offset="51" id="14573" />	<!--Shadow Brstplate-->
+		<item offset="52" id="14995" />	<!--Shadow Gauntlets-->
+		<item offset="53" id="15655" />	<!--Shadow Cuishes-->
+		<item offset="54" id="15740" />	<!--Shadow Sabatons-->
+		<item offset="55" id="16115" />	<!--Shadow Hat-->
+		<item offset="56" id="14575" />	<!--Shadow Coat-->
+		<item offset="57" id="14997" />	<!--Shadow Cuffs-->
+		<item offset="58" id="15657" />	<!--Shadow Trews-->
+		<item offset="59" id="15742" />	<!--Shadow Clogs-->
+		<item offset="60" id="16114" />	<!--Valkyrie's Helm-->
+		<item offset="61" id="14574" />	<!--Valk. Breastplate-->
+		<item offset="62" id="14996" />	<!--Valk. Gauntlets-->
+		<item offset="63" id="15656" />	<!--Valkyrie's Cuishes-->
+		<item offset="64" id="15741" />	<!--Valk. Sabatons-->
+		<item offset="65" id="16116" />	<!--Valkyrie's Hat-->
+		<item offset="66" id="14576" />	<!--Valkyrie's Coat-->
+		<item offset="67" id="14998" />	<!--Valkyrie's Cuffs-->
+		<item offset="68" id="15658" />	<!--Valkyrie's Trews-->
+		<item offset="69" id="15743" />	<!--Valkyrie's Clogs-->
+		<item offset="70" id="12818" />	<!--Byakko's Haidate-->
+		<item offset="71" id="18198" />	<!--Byakko's Axe-->
+		<item offset="72" id="12946" />	<!--Suzaku's Sune-Ate-->
+		<item offset="73" id="18043" />	<!--Suzaku's Scythe-->
+		<item offset="74" id="12690" />	<!--Seiryu's Kote-->
+		<item offset="75" id="17659" />	<!--Seiryu's Sword-->
+		<item offset="76" id="12296" />	<!--Genbu's Shield-->
+		<item offset="77" id="12434" />	<!--Genbu's Kabuto-->
+		<item offset="78" id="15471" />	<!--Merciful Cape-->
+		<item offset="79" id="15472" />	<!--Altruistic Cape-->
+		<item offset="80" id="15473" />	<!--Astute Cape-->
+		<item offset="81" id="15508" />	<!--Justice Torque-->
+		<item offset="82" id="15509" />	<!--Hope Torque-->
+		<item offset="83" id="15510" />	<!--Prudence Torque-->
+		<item offset="84" id="15511" />	<!--Fortitude Torque-->
+		<item offset="85" id="15512" />	<!--Faith Torque-->
+		<item offset="86" id="15513" />	<!--Temp. Torque-->
+		<item offset="87" id="15514" />	<!--Love Torque-->
+		<item offset="88" id="17710" />	<!--Justice Sword-->
+		<item offset="89" id="17595" />	<!--Hope Staff-->
+		<item offset="90" id="18397" />	<!--Prudence Rod-->
+		<item offset="91" id="18360" />	<!--Faith Baghnakhs-->
+		<item offset="92" id="18222" />	<!--Fortitude Axe-->
+		<item offset="93" id="17948" />	<!--Temperance Axe-->
+		<item offset="94" id="18100" />	<!--Love Halberd-->
+		<item offset="95" id="15475" />	<!--Charger Mantle-->
+		<item offset="96" id="15476" />	<!--Jaeger Mantle-->
+		<item offset="97" id="15477" />	<!--Boxer's Mantle-->
+		<item offset="98" id="15488" />	<!--Gunner's Mantle-->
+		<item offset="99" id="15961" />	<!--Musical Earring-->
+		<item offset="100" id="14815" />	<!--Stealth Earring-->
+		<item offset="101" id="14812" />	<!--Loquac. Earring-->
+		<item offset="102" id="14813" />	<!--Brutal Earring-->
+		<item offset="103" id="15244" />	<!--Flawless Ribbon-->
+		<item offset="104" id="15240" />	<!--Homam Zucchetto-->
+		<item offset="105" id="14488" />	<!--Homam Corazza-->
+		<item offset="106" id="14905" />	<!--Homam Manopolas-->
+		<item offset="107" id="15576" />	<!--Homam Cosciales-->
+		<item offset="108" id="15661" />	<!--Homam Gambieras-->
+		<item offset="109" id="15241" />	<!--Nashira Turban-->
+		<item offset="110" id="14489" />	<!--Nashira Manteel-->
+		<item offset="111" id="14906" />	<!--Nashira Gages-->
+		<item offset="112" id="15577" />	<!--Nashira Seraweels-->
+		<item offset="113" id="15662" />	<!--Nashira Crackows-->
+		<item offset="114" id="13927" />	<!--Hecatomb Cap-->
+		<item offset="115" id="14378" />	<!--Hecatomb Harness-->
+		<item offset="116" id="14076" />	<!--Hecatomb Mittens-->
+		<item offset="117" id="14308" />	<!--Hecatomb Subligar-->
+		<item offset="118" id="14180" />	<!--Hct. Leggings-->
+		<item offset="119" id="13928" />	<!--Hecatomb Cap +1-->
+		<item offset="120" id="14379" />	<!--Hct. Harness +1-->
+		<item offset="121" id="14077" />	<!--Hct. Mittens +1-->
+		<item offset="122" id="14309" />	<!--Hct. Subligar +1-->
+		<item offset="123" id="14181" />	<!--Hct. Leggings +1-->
+		<item offset="124" id="10438" />	<!--Enif Zucchetto-->
+		<item offset="125" id="10276" />	<!--Enif Corazza-->
+		<item offset="126" id="10320" />	<!--Enif Manopolas-->
+		<item offset="127" id="10326" />	<!--Enif Cosciales-->
+		<item offset="128" id="10367" />	<!--Enif Gambieras-->
+		<item offset="129" id="10439" />	<!--Adhara Turban-->
+		<item offset="130" id="10277" />	<!--Adhara Manteel-->
+		<item offset="131" id="10321" />	<!--Adhara Gages-->
+		<item offset="132" id="10327" />	<!--Adhara Seraweels-->
+		<item offset="133" id="10368" />	<!--Adhara Crackows-->
+		<item offset="134" id="10440" />	<!--Murzim Zucchetto-->
+		<item offset="135" id="10278" />	<!--Murzim Corazza-->
+		<item offset="136" id="10322" />	<!--Murzim Manopolas-->
+		<item offset="137" id="10328" />	<!--Murzim Cosciales-->
+		<item offset="138" id="10369" />	<!--Murzim Gambieras-->
+		<item offset="139" id="10441" />	<!--Shedir Turban-->
+		<item offset="140" id="10279" />	<!--Shedir Manteel-->
+		<item offset="141" id="10323" />	<!--Shedir Gages-->
+		<item offset="142" id="10329" />	<!--Shedir Seraweels-->
+		<item offset="143" id="10370" />	<!--Shedir Crackows-->
+		<item offset="144" id="25734" />	<!--Pieuje Unity Shirt-->
+		<item offset="145" id="25735" />	<!--Ayame Unity Shirt-->
+		<item offset="146" id="25736" />	<!--I. Shield Unity Shirt-->
+		<item offset="147" id="25737" />	<!--Apururu Unity Shirt-->
+		<item offset="148" id="25738" />	<!--Maat Unity Shirt-->
+		<item offset="149" id="25739" />	<!--Aldo Unity Shirt-->
+		<item offset="150" id="25740" />	<!--Jakoh Unity Shirt-->
+		<item offset="151" id="25741" />	<!--Naja Unity Shirt-->
+		<item offset="152" id="25742" />	<!--Flaviria Unity Shirt-->
+		<item offset="153" id="25743" />	<!--Yoran Unity Shirt-->
+		<item offset="154" id="25744" />	<!--Sylvie Unity Shirt-->
+	</slip>
+	<slip id="29314">		<!--Storage Slip 03-->
+		<item offset="0" id="16155" />	<!--Aurum Armet-->
+		<item offset="1" id="11282" />	<!--Aurum Cuirass-->
+		<item offset="2" id="15021" />	<!--Aurum Gauntlets-->
+		<item offset="3" id="16341" />	<!--Aurum Cuisses-->
+		<item offset="4" id="11376" />	<!--Aurum Sabatons-->
+		<item offset="5" id="16156" />	<!--Oracle's Cap-->
+		<item offset="6" id="11283" />	<!--Oracle's Robe-->
+		<item offset="7" id="15022" />	<!--Oracle's Gloves-->
+		<item offset="8" id="16342" />	<!--Oracle's Braconi-->
+		<item offset="9" id="11377" />	<!--Oracle's Pigaches-->
+		<item offset="10" id="16157" />	<!--Enkidu's Cap-->
+		<item offset="11" id="11284" />	<!--Enkidu's Harness-->
+		<item offset="12" id="15023" />	<!--Enkidu's Mittens-->
+		<item offset="13" id="16343" />	<!--Enkidu's Subligar-->
+		<item offset="14" id="11378" />	<!--Enkidu's Leggings-->
+		<item offset="15" id="16148" />	<!--Cobra Cap-->
+		<item offset="16" id="14590" />	<!--Cobra Harness-->
+		<item offset="17" id="15011" />	<!--Cobra Mittens-->
+		<item offset="18" id="16317" />	<!--Cobra Subligar-->
+		<item offset="19" id="15757" />	<!--Cobra Leggings-->
+		<item offset="20" id="16143" />	<!--Cobra Hat-->
+		<item offset="21" id="14591" />	<!--Cobra Robe-->
+		<item offset="22" id="15012" />	<!--Cobra Gloves-->
+		<item offset="23" id="16318" />	<!--Cobra Trews-->
+		<item offset="24" id="15758" />	<!--Cobra Crackows-->
+		<item offset="25" id="16146" />	<!--Iron Ram Sallet-->
+		<item offset="26" id="14588" />	<!--Iron Ram Hauberk-->
+		<item offset="27" id="15009" />	<!--I.R. Dastanas-->
+		<item offset="28" id="16315" />	<!--Iron Ram Hose-->
+		<item offset="29" id="15755" />	<!--Iron Ram Greaves-->
+		<item offset="30" id="16147" />	<!--Fourth Haube-->
+		<item offset="31" id="14589" />	<!--Fourth Brunne-->
+		<item offset="32" id="15010" />	<!--Fourth Hentzes-->
+		<item offset="33" id="16316" />	<!--Fourth Schoss-->
+		<item offset="34" id="15756" />	<!--Fourth Schuhs-->
+		<item offset="35" id="15966" />	<!--Silver Fox Earring-->
+		<item offset="36" id="15967" />	<!--Temple Earring-->
+		<item offset="37" id="19041" />	<!--Rose Strap-->
+		<item offset="38" id="17684" />	<!--Griffinclaw-->
+		<item offset="39" id="17685" />	<!--Lex Talionis-->
+		<item offset="40" id="11636" />	<!--R.K. Sigil Ring-->
+		<item offset="41" id="15844" />	<!--Patronus Ring-->
+		<item offset="42" id="15934" />	<!--Crimson Belt-->
+		<item offset="43" id="16258" />	<!--Arrestor Mantle-->
+		<item offset="44" id="18735" />	<!--Sonia's Plectrum-->
+		<item offset="45" id="18734" />	<!--Sturm's Report-->
+		<item offset="46" id="16291" />	<!--Shield Collar-->
+		<item offset="47" id="16292" />	<!--Bull Necklace-->
+		<item offset="48" id="19042" />	<!--Ariesian Grip-->
+		<item offset="49" id="15935" />	<!--Capricornian Rope-->
+		<item offset="50" id="16293" />	<!--Cougar Pendant-->
+		<item offset="51" id="16294" />	<!--Crocodile Collar-->
+		<item offset="52" id="15936" />	<!--Earthy Belt-->
+		<item offset="53" id="18618" />	<!--Samudra-->
+		<item offset="54" id="11588" />	<!--Mrc.Mjr. Charm-->
+		<item offset="55" id="11545" />	<!--Fourth Mantle-->
+		<item offset="56" id="16158" />	<!--Gnadbhod's Helm-->
+		<item offset="57" id="16159" />	<!--Zha'Go's Barbut-->
+		<item offset="58" id="16160" />	<!--Ree's Headgear-->
+		<item offset="59" id="16149" />	<!--Cobra Cloche-->
+		<item offset="60" id="14583" />	<!--Cobra Coat-->
+		<item offset="61" id="15007" />	<!--Cobra Cuffs-->
+		<item offset="62" id="16314" />	<!--Cobra Slops-->
+		<item offset="63" id="15751" />	<!--Cobra Pigaches-->
+		<item offset="64" id="16141" />	<!--Iron Ram Helm-->
+		<item offset="65" id="14581" />	<!--I.R. Chainmail-->
+		<item offset="66" id="15005" />	<!--Iron Ram Mufflers-->
+		<item offset="67" id="16312" />	<!--I.R. Breeches-->
+		<item offset="68" id="15749" />	<!--I.R. Sollerets-->
+		<item offset="69" id="16142" />	<!--Fourth Armet-->
+		<item offset="70" id="14582" />	<!--Fourth Cuirass-->
+		<item offset="71" id="15006" />	<!--Fourth Gauntlets-->
+		<item offset="72" id="16313" />	<!--Fourth Cuisses-->
+		<item offset="73" id="15750" />	<!--Fourth Sabatons-->
+		<item offset="74" id="10876" />	<!--Ogier's Helm-->
+		<item offset="75" id="10450" />	<!--Ogier's Surcoat-->
+		<item offset="76" id="10500" />	<!--Ogier's Gauntlets-->
+		<item offset="77" id="11969" />	<!--Ogier's Breeches-->
+		<item offset="78" id="10600" />	<!--Ogier's Leggings-->
+		<item offset="79" id="10877" />	<!--Athos's Chapeau-->
+		<item offset="80" id="10451" />	<!--Athos's Tabard-->
+		<item offset="81" id="10501" />	<!--Athos's Gloves-->
+		<item offset="82" id="11970" />	<!--Athos's Tights-->
+		<item offset="83" id="10601" />	<!--Athos's Boots-->
+		<item offset="84" id="10878" />	<!--Rubeus Bandeau-->
+		<item offset="85" id="10452" />	<!--Rubeus Jacket-->
+		<item offset="86" id="10502" />	<!--Rubeus Gloves-->
+		<item offset="87" id="11971" />	<!--Rubeus Spats-->
+		<item offset="88" id="10602" />	<!--Rubeus Boots-->
+		<item offset="89" id="19132" />	<!--Twilight Knife-->
+		<item offset="90" id="18551" />	<!--Twilight Scythe-->
+		<item offset="91" id="11798" />	<!--Twilight Helm-->
+		<item offset="92" id="11362" />	<!--Twilight Mail-->
+		<item offset="93" id="11363" />	<!--Twilight Cloak-->
+		<item offset="94" id="11625" />	<!--Twilight Torque-->
+		<item offset="95" id="15959" />	<!--Twilight Belt-->
+		<item offset="96" id="16259" />	<!--Twilight Cape-->
+		<item offset="97" id="22299" />	<!--Per. Lucky Egg-->
+		<item offset="98" id="26414" />	<!--Twinned Shield-->
+		<item offset="99" id="21623" />	<!--Twinned Blade-->
+		<item offset="100" id="26219" />	<!--Naji's Loop-->
+		<item offset="101" id="21886" />	<!--Iapetus-->
+		<item offset="102" id="23792" />	<!--Ziamet Khud-->
+		<item offset="103" id="23793" />	<!--Ziamet Peti-->
+		<item offset="104" id="23794" />	<!--Ziamet Bazubands-->
+		<item offset="105" id="23795" />	<!--Ziamet Salvars-->
+		<item offset="106" id="23796" />	<!--Ziamet Nails-->
+		<item offset="107" id="22032" />	<!--Thunder Hammer-->
+		<item offset="108" id="22043" />	<!--Apkallu Scepter-->
+		<item offset="109" id="21530" />	<!--Tokkosho-->
+		<item offset="110" id="22044" />	<!--Tengu War Fan-->
+		<item offset="111" id="26273" />	<!--Tengu Shawl-->
+		<item offset="112" id="25415" />	<!--Rep. Plat. Medal-->
+		<item offset="113" id="25416" />	<!--Sibyl Scarf-->
+		<item offset="114" id="25414" />	<!--Elite Royal Collar-->
+		<item offset="115" id="22050" />	<!--Chac-chacs-->
+		<item offset="116" id="22302" />	<!--Oshasha's Treatise-->
+		<item offset="117" id="26365" />	<!--Cornelia's Belt-->
+		<item offset="118" id="26366" />	<!--Plat. Mog. Belt-->
+		<item offset="119" id="23862" />	<!--Boudox's Masque-->
+		<item offset="120" id="23863" />	<!--Boudox's Suit-->
+		<item offset="121" id="23864" />	<!--Magh Bihu's Masque-->
+		<item offset="122" id="23865" />	<!--Magh Bihu's Suit-->
+		<item offset="123" id="21536" />	<!--Dazbog's Knuckles-->
+	</slip>
+	<slip id="29315">		<!--Storage Slip 04-->
+		<item offset="0" id="12511" />	<!--Fighter's Mask-->
+		<item offset="1" id="12638" />	<!--Fighter's Lorica-->
+		<item offset="2" id="13961" />	<!--Fighter's Mufflers-->
+		<item offset="3" id="14214" />	<!--Fighter's Cuisses-->
+		<item offset="4" id="14089" />	<!--Fighter's Calligae-->
+		<item offset="5" id="12512" />	<!--Temple Crown-->
+		<item offset="6" id="12639" />	<!--Temple Cyclas-->
+		<item offset="7" id="13962" />	<!--Temple Gloves-->
+		<item offset="8" id="14215" />	<!--Temple Hose-->
+		<item offset="9" id="14090" />	<!--Temple Gaiters-->
+		<item offset="10" id="13855" />	<!--Healer's Cap-->
+		<item offset="11" id="12640" />	<!--Healer's Bliaut-->
+		<item offset="12" id="13963" />	<!--Healer's Mitts-->
+		<item offset="13" id="14216" />	<!--Healer's Pantaln.-->
+		<item offset="14" id="14091" />	<!--Healer's Duckbills-->
+		<item offset="15" id="13856" />	<!--Wizard's Petasos-->
+		<item offset="16" id="12641" />	<!--Wizard's Coat-->
+		<item offset="17" id="13964" />	<!--Wizard's Gloves-->
+		<item offset="18" id="14217" />	<!--Wizard's Tonban-->
+		<item offset="19" id="14092" />	<!--Wizard's Sabots-->
+		<item offset="20" id="12513" />	<!--Warlock's Chapeau-->
+		<item offset="21" id="12642" />	<!--Warlock's Tabard-->
+		<item offset="22" id="13965" />	<!--Warlock's Gloves-->
+		<item offset="23" id="14218" />	<!--Warlock's Tights-->
+		<item offset="24" id="14093" />	<!--Warlock's Boots-->
+		<item offset="25" id="12514" />	<!--Rogue's Bonnet-->
+		<item offset="26" id="12643" />	<!--Rogue's Vest-->
+		<item offset="27" id="13966" />	<!--Rogue's Armlets-->
+		<item offset="28" id="14219" />	<!--Rogue's Culottes-->
+		<item offset="29" id="14094" />	<!--Rogue's Poulaines-->
+		<item offset="30" id="12515" />	<!--Gallant Coronet-->
+		<item offset="31" id="12644" />	<!--Gallant Surcoat-->
+		<item offset="32" id="13967" />	<!--Gallant Gauntlets-->
+		<item offset="33" id="14220" />	<!--Gallant Breeches-->
+		<item offset="34" id="14095" />	<!--Gallant Leggings-->
+		<item offset="35" id="12516" />	<!--Chaos Burgeonet-->
+		<item offset="36" id="12645" />	<!--Chaos Cuirass-->
+		<item offset="37" id="13968" />	<!--Chaos Gauntlets-->
+		<item offset="38" id="14221" />	<!--Chaos Flanchard-->
+		<item offset="39" id="14096" />	<!--Chaos Sollerets-->
+		<item offset="40" id="12517" />	<!--Beast Helm-->
+		<item offset="41" id="12646" />	<!--Beast Jackcoat-->
+		<item offset="42" id="13969" />	<!--Beast Gloves-->
+		<item offset="43" id="14222" />	<!--Beast Trousers-->
+		<item offset="44" id="14097" />	<!--Beast Gaiters-->
+		<item offset="45" id="13857" />	<!--Choral Roundlet-->
+		<item offset="46" id="12647" />	<!--Choral Jstcorps-->
+		<item offset="47" id="13970" />	<!--Choral Cuffs-->
+		<item offset="48" id="14223" />	<!--Choral Cannions-->
+		<item offset="49" id="14098" />	<!--Choral Slippers-->
+		<item offset="50" id="12518" />	<!--Hunter's Beret-->
+		<item offset="51" id="12648" />	<!--Hunter's Jerkin-->
+		<item offset="52" id="13971" />	<!--Hunter's Bracers-->
+		<item offset="53" id="14224" />	<!--Hunter's Braccae-->
+		<item offset="54" id="14099" />	<!--Hunter's Socks-->
+		<item offset="55" id="13868" />	<!--Myochin Kabuto-->
+		<item offset="56" id="13781" />	<!--Myochin Domaru-->
+		<item offset="57" id="13972" />	<!--Myochin Kote-->
+		<item offset="58" id="14225" />	<!--Myochin Haidate-->
+		<item offset="59" id="14100" />	<!--Myochin Sune-Ate-->
+		<item offset="60" id="13869" />	<!--Ninja Hatsuburi-->
+		<item offset="61" id="13782" />	<!--Ninja Chainmail-->
+		<item offset="62" id="13973" />	<!--Ninja Tekko-->
+		<item offset="63" id="14226" />	<!--Ninja Hakama-->
+		<item offset="64" id="14101" />	<!--Ninja Kyahan-->
+		<item offset="65" id="12519" />	<!--Drachen Armet-->
+		<item offset="66" id="12649" />	<!--Drachen Mail-->
+		<item offset="67" id="13974" />	<!--Drachen Fng. Gnt.-->
+		<item offset="68" id="14227" />	<!--Drachen Brais-->
+		<item offset="69" id="14102" />	<!--Drachen Greaves-->
+		<item offset="70" id="12520" />	<!--Evoker's Horn-->
+		<item offset="71" id="12650" />	<!--Evoker's Doublet-->
+		<item offset="72" id="13975" />	<!--Evoker's Bracers-->
+		<item offset="73" id="14228" />	<!--Evoker's Spats-->
+		<item offset="74" id="14103" />	<!--Evoker's Pigaches-->
+		<item offset="75" id="15265" />	<!--Magus Keffiyeh-->
+		<item offset="76" id="14521" />	<!--Magus Jubbah-->
+		<item offset="77" id="14928" />	<!--Magus Bazubands-->
+		<item offset="78" id="15600" />	<!--Magus Shalwar-->
+		<item offset="79" id="15684" />	<!--Magus Charuqs-->
+		<item offset="80" id="15266" />	<!--Corsair's Tricorne-->
+		<item offset="81" id="14522" />	<!--Corsair's Frac-->
+		<item offset="82" id="14929" />	<!--Corsair's Gants-->
+		<item offset="83" id="15601" />	<!--Corsair's Culottes-->
+		<item offset="84" id="15685" />	<!--Corsair's Bottes-->
+		<item offset="85" id="15267" />	<!--Pup. Taj-->
+		<item offset="86" id="14523" />	<!--Pup. Tobe-->
+		<item offset="87" id="14930" />	<!--Pup. Dastanas-->
+		<item offset="88" id="15602" />	<!--Pup. Churidars-->
+		<item offset="89" id="15686" />	<!--Pup. Babouches-->
+		<item offset="90" id="16138" />	<!--Dancer's Tiara-->
+		<item offset="91" id="14578" />	<!--Dancer's Casaque-->
+		<item offset="92" id="15002" />	<!--Dancer's Bangles-->
+		<item offset="93" id="15659" />	<!--Dancer's Tights-->
+		<item offset="94" id="15746" />	<!--Dancer's Toe Shoes-->
+		<item offset="95" id="16139" />	<!--Dancer's Tiara-->
+		<item offset="96" id="14579" />	<!--Dancer's Casaque-->
+		<item offset="97" id="15003" />	<!--Dancer's Bangles-->
+		<item offset="98" id="15660" />	<!--Dancer's Tights-->
+		<item offset="99" id="15747" />	<!--Dancer's Toe Shoes-->
+		<item offset="100" id="16140" />	<!--Scholar's M.board-->
+		<item offset="101" id="14580" />	<!--Scholar's Gown-->
+		<item offset="102" id="15004" />	<!--Scholar's Bracers-->
+		<item offset="103" id="16311" />	<!--Scholar's Pants-->
+		<item offset="104" id="15748" />	<!--Scholar's Loafers-->
+		<item offset="105" id="16678" />	<!--Razor Axe-->
+		<item offset="106" id="17478" />	<!--Beat Cesti-->
+		<item offset="107" id="17422" />	<!--Blessed Hammer-->
+		<item offset="108" id="17423" />	<!--Casting Wand-->
+		<item offset="109" id="16829" />	<!--Fencing Degen-->
+		<item offset="110" id="16764" />	<!--Marauder's Knife-->
+		<item offset="111" id="17643" />	<!--Honor Sword-->
+		<item offset="112" id="16798" />	<!--Raven Scythe-->
+		<item offset="113" id="16680" />	<!--Barbaroi Axe-->
+		<item offset="114" id="16766" />	<!--Paper Knife-->
+		<item offset="115" id="17188" />	<!--Sniping Bow-->
+		<item offset="116" id="17812" />	<!--Magoroku-->
+		<item offset="117" id="17771" />	<!--Anju-->
+		<item offset="118" id="17772" />	<!--Zushio-->
+		<item offset="119" id="16887" />	<!--Peregrine-->
+		<item offset="120" id="17532" />	<!--Kukulcan's Staff-->
+		<item offset="121" id="17717" />	<!--Immortal's Scimitar-->
+		<item offset="122" id="18702" />	<!--Trump Gun-->
+		<item offset="123" id="17858" />	<!--Turbo Animator-->
+		<item offset="124" id="19203" />	<!--War Hoop-->
+		<item offset="125" id="21461" />	<!--Filiae Bell-->
+		<item offset="126" id="21124" />	<!--Dowser's Wand-->
+		<item offset="127" id="20776" />	<!--Beorc Sword-->
+		<item offset="128" id="27786" />	<!--Geomancy Galero-->
+		<item offset="129" id="27926" />	<!--Geomancy Tunic-->
+		<item offset="130" id="28066" />	<!--Geomancy Mitaines-->
+		<item offset="131" id="28206" />	<!--Geomancy Pants-->
+		<item offset="132" id="28346" />	<!--Geomancy Sandals-->
+		<item offset="133" id="27787" />	<!--Runeist Bandeau-->
+		<item offset="134" id="27927" />	<!--Runeist Coat-->
+		<item offset="135" id="28067" />	<!--Runeist Mitons-->
+		<item offset="136" id="28207" />	<!--Runeist Trousers-->
+		<item offset="137" id="28347" />	<!--Runeist Bottes-->
+	</slip>
+	<slip id="29316">		<!--Storage Slip 05-->
+		<item offset="0" id="15225" />	<!--Ftr. Mask +1-->
+		<item offset="1" id="14473" />	<!--Ftr. Lorica +1-->
+		<item offset="2" id="14890" />	<!--Ftr. Mufflers +1-->
+		<item offset="3" id="15561" />	<!--Ftr. Cuisses +1-->
+		<item offset="4" id="15352" />	<!--Ftr. Calligae +1-->
+		<item offset="5" id="15226" />	<!--Tpl. Crown +1-->
+		<item offset="6" id="14474" />	<!--Tpl. Cyclas +1-->
+		<item offset="7" id="14891" />	<!--Tpl. Gloves +1-->
+		<item offset="8" id="15562" />	<!--Tpl. Hose +1-->
+		<item offset="9" id="15353" />	<!--Tpl. Gaiters +1-->
+		<item offset="10" id="15227" />	<!--Hlr. Cap +1-->
+		<item offset="11" id="14475" />	<!--Hlr. Bliaut +1-->
+		<item offset="12" id="14892" />	<!--Hlr. Mitts +1-->
+		<item offset="13" id="15563" />	<!--Hlr. Pantaln. +1-->
+		<item offset="14" id="15354" />	<!--Hlr. Duckbills +1-->
+		<item offset="15" id="15228" />	<!--Wzd. Petasos +1-->
+		<item offset="16" id="14476" />	<!--Wzd. Coat +1-->
+		<item offset="17" id="14893" />	<!--Wzd. Gloves +1-->
+		<item offset="18" id="15564" />	<!--Wzd. Tonban +1-->
+		<item offset="19" id="15355" />	<!--Wzd. Sabots +1-->
+		<item offset="20" id="15229" />	<!--Wlk. Chapeau +1-->
+		<item offset="21" id="14477" />	<!--Wlk. Tabard +1-->
+		<item offset="22" id="14894" />	<!--Wlk. Gloves +1-->
+		<item offset="23" id="15565" />	<!--Wlk. Tights +1-->
+		<item offset="24" id="15356" />	<!--Wlk. Boots +1-->
+		<item offset="25" id="15230" />	<!--Rog. Bonnet +1-->
+		<item offset="26" id="14478" />	<!--Rog. Vest +1-->
+		<item offset="27" id="14895" />	<!--Rog. Armlets +1-->
+		<item offset="28" id="15566" />	<!--Rog. Culottes +1-->
+		<item offset="29" id="15357" />	<!--Rog. Poulaines +1-->
+		<item offset="30" id="15231" />	<!--Glt. Coronet +1-->
+		<item offset="31" id="14479" />	<!--Glt. Surcoat +1-->
+		<item offset="32" id="14896" />	<!--Glt. Gauntlets +1-->
+		<item offset="33" id="15567" />	<!--Glt. Breeches +1-->
+		<item offset="34" id="15358" />	<!--Glt. Leggings +1-->
+		<item offset="35" id="15232" />	<!--Chs. Burgeonet +1-->
+		<item offset="36" id="14480" />	<!--Chs. Cuirass +1-->
+		<item offset="37" id="14897" />	<!--Chs. Gauntlets +1-->
+		<item offset="38" id="15568" />	<!--Chs. Flanchard +1-->
+		<item offset="39" id="15359" />	<!--Chs. Sollerets +1-->
+		<item offset="40" id="15233" />	<!--Bst. Helm +1-->
+		<item offset="41" id="14481" />	<!--Bst. Jackcoat +1-->
+		<item offset="42" id="14898" />	<!--Bst. Gloves +1-->
+		<item offset="43" id="15569" />	<!--Bst. Trousers +1-->
+		<item offset="44" id="15360" />	<!--Bst. Gaiters +1-->
+		<item offset="45" id="15234" />	<!--Chl. Roundlet +1-->
+		<item offset="46" id="14482" />	<!--Chl. Jstcorps +1-->
+		<item offset="47" id="14899" />	<!--Chl. Cuffs +1-->
+		<item offset="48" id="15570" />	<!--Chl. Cannions +1-->
+		<item offset="49" id="15361" />	<!--Chl. Slippers +1-->
+		<item offset="50" id="15235" />	<!--Htr. Beret +1-->
+		<item offset="51" id="14483" />	<!--Htr. Jerkin +1-->
+		<item offset="52" id="14900" />	<!--Htr. Bracers +1-->
+		<item offset="53" id="15362" />	<!--Htr. Socks +1-->
+		<item offset="54" id="15571" />	<!--Htr. Braccae +1-->
+		<item offset="55" id="15236" />	<!--Myn. Kabuto +1-->
+		<item offset="56" id="14484" />	<!--Myn. Domaru +1-->
+		<item offset="57" id="14901" />	<!--Myn. Kote +1-->
+		<item offset="58" id="15572" />	<!--Myn. Haidate +1-->
+		<item offset="59" id="15363" />	<!--Myn. Sune-Ate +1-->
+		<item offset="60" id="15237" />	<!--Nin. Hatsuburi +1-->
+		<item offset="61" id="14485" />	<!--Nin. Chainmail +1-->
+		<item offset="62" id="14902" />	<!--Nin. Tekko +1-->
+		<item offset="63" id="15573" />	<!--Nin. Hakama +1-->
+		<item offset="64" id="15364" />	<!--Nin. Kyahan +1-->
+		<item offset="65" id="15238" />	<!--Drn. Armet +1-->
+		<item offset="66" id="14486" />	<!--Drn. Mail +1-->
+		<item offset="67" id="14903" />	<!--Drn. Fng. Gnt. +1-->
+		<item offset="68" id="15574" />	<!--Drn. Brais +1-->
+		<item offset="69" id="15365" />	<!--Drn. Greaves +1-->
+		<item offset="70" id="15239" />	<!--Evk. Horn +1-->
+		<item offset="71" id="14487" />	<!--Evk. Doublet +1-->
+		<item offset="72" id="14904" />	<!--Evk. Bracers +1-->
+		<item offset="73" id="15575" />	<!--Evk. Spats +1-->
+		<item offset="74" id="15366" />	<!--Evk. Pigaches +1-->
+		<item offset="75" id="11464" />	<!--Magus Keffiyeh +1-->
+		<item offset="76" id="11291" />	<!--Magus Jubbah +1-->
+		<item offset="77" id="15024" />	<!--Mag. Bazubands +1-->
+		<item offset="78" id="16345" />	<!--Magus Shalwar +1-->
+		<item offset="79" id="11381" />	<!--Magus Charuqs +1-->
+		<item offset="80" id="11467" />	<!--Cor. Tricorne +1-->
+		<item offset="81" id="11294" />	<!--Corsair's Frac +1-->
+		<item offset="82" id="15027" />	<!--Corsair's Gants +1-->
+		<item offset="83" id="16348" />	<!--Cor. Culottes +1-->
+		<item offset="84" id="11384" />	<!--Cor. Bottes +1-->
+		<item offset="85" id="11470" />	<!--Puppetry Taj +1-->
+		<item offset="86" id="11297" />	<!--Pup. Tobe +1-->
+		<item offset="87" id="15030" />	<!--Pup. Dastanas +1-->
+		<item offset="88" id="16351" />	<!--Pup. Churidars +1-->
+		<item offset="89" id="11387" />	<!--Pup. Babouches +1-->
+		<item offset="90" id="11475" />	<!--Dancer's Tiara +1-->
+		<item offset="91" id="11302" />	<!--Dnc. Casaque +1-->
+		<item offset="92" id="15035" />	<!--Dnc. Bangles +1-->
+		<item offset="93" id="16357" />	<!--Dancer's Tights +1-->
+		<item offset="94" id="11393" />	<!--Dnc. Toe Shoes +1-->
+		<item offset="95" id="11476" />	<!--Dancer's Tiara +1-->
+		<item offset="96" id="11303" />	<!--Dnc. Casaque +1-->
+		<item offset="97" id="15036" />	<!--Dnc. Bangles +1-->
+		<item offset="98" id="16358" />	<!--Dancer's Tights +1-->
+		<item offset="99" id="11394" />	<!--Dnc. Toe Shoes +1-->
+		<item offset="100" id="11477" />	<!--Sch. M.board +1-->
+		<item offset="101" id="11304" />	<!--Scholar's Gown +1-->
+		<item offset="102" id="15037" />	<!--Sch. Bracers +1-->
+		<item offset="103" id="16359" />	<!--Scholar's Pants +1-->
+		<item offset="104" id="11395" />	<!--Sch. Loafers +1-->
+	</slip>
+	<slip id="29317">		<!--Storage Slip 06-->
+		<item offset="0" id="15072" />	<!--Warrior's Mask-->
+		<item offset="1" id="15087" />	<!--Warrior's Lorica-->
+		<item offset="2" id="15102" />	<!--Warrior's Mufflers-->
+		<item offset="3" id="15117" />	<!--Warrior's Cuisses-->
+		<item offset="4" id="15132" />	<!--Warrior's Calligae-->
+		<item offset="5" id="15871" />	<!--Warrior's Stone-->
+		<item offset="6" id="15073" />	<!--Melee Crown-->
+		<item offset="7" id="15088" />	<!--Melee Cyclas-->
+		<item offset="8" id="15103" />	<!--Melee Gloves-->
+		<item offset="9" id="15118" />	<!--Melee Hose-->
+		<item offset="10" id="15133" />	<!--Melee Gaiters-->
+		<item offset="11" id="15478" />	<!--Melee Cape-->
+		<item offset="12" id="15074" />	<!--Cleric's Cap-->
+		<item offset="13" id="15089" />	<!--Cleric's Bliaut-->
+		<item offset="14" id="15104" />	<!--Cleric's Mitts-->
+		<item offset="15" id="15119" />	<!--Cleric's Pantaln.-->
+		<item offset="16" id="15134" />	<!--Cleric's Duckbills-->
+		<item offset="17" id="15872" />	<!--Cleric's Belt-->
+		<item offset="18" id="15075" />	<!--Sorcerer's Petas.-->
+		<item offset="19" id="15090" />	<!--Sorcerer's Coat-->
+		<item offset="20" id="15105" />	<!--Sorcerer's Gloves-->
+		<item offset="21" id="15120" />	<!--Sorcerer's Tonban-->
+		<item offset="22" id="15135" />	<!--Sorcerer's Sabots-->
+		<item offset="23" id="15874" />	<!--Sorcerer's Belt-->
+		<item offset="24" id="15076" />	<!--Duelist's Chapeau-->
+		<item offset="25" id="15091" />	<!--Duelist's Tabard-->
+		<item offset="26" id="15106" />	<!--Duelist's Gloves-->
+		<item offset="27" id="15121" />	<!--Duelist's Tights-->
+		<item offset="28" id="15136" />	<!--Duelist's Boots-->
+		<item offset="29" id="15873" />	<!--Duelist's Belt-->
+		<item offset="30" id="15077" />	<!--Assassin's Bonnet-->
+		<item offset="31" id="15092" />	<!--Assassin's Vest-->
+		<item offset="32" id="15107" />	<!--Assassin's Armlets-->
+		<item offset="33" id="15122" />	<!--Assassin's Culottes-->
+		<item offset="34" id="15137" />	<!--Assassin's Pouln.-->
+		<item offset="35" id="15480" />	<!--Assassin's Cape-->
+		<item offset="36" id="15078" />	<!--Valor Coronet-->
+		<item offset="37" id="15093" />	<!--Valor Surcoat-->
+		<item offset="38" id="15108" />	<!--Valor Gauntlets-->
+		<item offset="39" id="15123" />	<!--Valor Breeches-->
+		<item offset="40" id="15138" />	<!--Valor Leggings-->
+		<item offset="41" id="15481" />	<!--Valor Cape-->
+		<item offset="42" id="15079" />	<!--Abyss Burgeonet-->
+		<item offset="43" id="15094" />	<!--Abyss Cuirass-->
+		<item offset="44" id="15109" />	<!--Abyss Gauntlets-->
+		<item offset="45" id="15124" />	<!--Abyss Flanchard-->
+		<item offset="46" id="15139" />	<!--Abyss Sollerets-->
+		<item offset="47" id="15479" />	<!--Abyss Cape-->
+		<item offset="48" id="15080" />	<!--Monster Helm-->
+		<item offset="49" id="15095" />	<!--Monster Jackcoat-->
+		<item offset="50" id="15110" />	<!--Monster Gloves-->
+		<item offset="51" id="15125" />	<!--Monster Trousers-->
+		<item offset="52" id="15140" />	<!--Monster Gaiters-->
+		<item offset="53" id="15875" />	<!--Monster Belt-->
+		<item offset="54" id="15081" />	<!--Bard's Roundlet-->
+		<item offset="55" id="15096" />	<!--Bard's Jstcorps-->
+		<item offset="56" id="15111" />	<!--Bard's Cuffs-->
+		<item offset="57" id="15126" />	<!--Bard's Cannions-->
+		<item offset="58" id="15141" />	<!--Bard's Slippers-->
+		<item offset="59" id="15482" />	<!--Bard's Cape-->
+		<item offset="60" id="15082" />	<!--Scout's Beret-->
+		<item offset="61" id="15097" />	<!--Scout's Jerkin-->
+		<item offset="62" id="15112" />	<!--Scout's Bracers-->
+		<item offset="63" id="15127" />	<!--Scout's Braccae-->
+		<item offset="64" id="15142" />	<!--Scout's Socks-->
+		<item offset="65" id="15876" />	<!--Scout's Belt-->
+		<item offset="66" id="15083" />	<!--Saotome Kabuto-->
+		<item offset="67" id="15098" />	<!--Saotome Domaru-->
+		<item offset="68" id="15113" />	<!--Saotome Kote-->
+		<item offset="69" id="15128" />	<!--Saotome Haidate-->
+		<item offset="70" id="15143" />	<!--Saotome Sune-Ate-->
+		<item offset="71" id="15879" />	<!--Sao. Koshi-Ate-->
+		<item offset="72" id="15084" />	<!--Koga Hatsuburi-->
+		<item offset="73" id="15099" />	<!--Koga Chainmail-->
+		<item offset="74" id="15114" />	<!--Koga Tekko-->
+		<item offset="75" id="15129" />	<!--Koga Hakama-->
+		<item offset="76" id="15144" />	<!--Koga Kyahan-->
+		<item offset="77" id="15877" />	<!--Koga Sarashi-->
+		<item offset="78" id="15085" />	<!--Wyrm Armet-->
+		<item offset="79" id="15100" />	<!--Wyrm Mail-->
+		<item offset="80" id="15115" />	<!--Wyrm Fng.Gnt.-->
+		<item offset="81" id="15130" />	<!--Wyrm Brais-->
+		<item offset="82" id="15145" />	<!--Wyrm Greaves-->
+		<item offset="83" id="15878" />	<!--Wyrm Belt-->
+		<item offset="84" id="15086" />	<!--Summoner's Horn-->
+		<item offset="85" id="15101" />	<!--Summoner's Dblt.-->
+		<item offset="86" id="15116" />	<!--Summoner's Brcr.-->
+		<item offset="87" id="15131" />	<!--Summoner's Spats-->
+		<item offset="88" id="15146" />	<!--Summoner's Pgch.-->
+		<item offset="89" id="15484" />	<!--Summoner's Cape-->
+		<item offset="90" id="11465" />	<!--Mirage Keffiyeh-->
+		<item offset="91" id="11292" />	<!--Mirage Jubbah-->
+		<item offset="92" id="15025" />	<!--Mirage Bazubands-->
+		<item offset="93" id="16346" />	<!--Mirage Shalwar-->
+		<item offset="94" id="11382" />	<!--Mirage Charuqs-->
+		<item offset="95" id="16244" />	<!--Mirage Mantle-->
+		<item offset="96" id="11468" />	<!--Comm. Tricorne-->
+		<item offset="97" id="11295" />	<!--Commodore Frac-->
+		<item offset="98" id="15028" />	<!--Commodore Gants-->
+		<item offset="99" id="16349" />	<!--Comm. Trews-->
+		<item offset="100" id="11385" />	<!--Comm. Bottes-->
+		<item offset="101" id="15920" />	<!--Commodore Belt-->
+		<item offset="102" id="11471" />	<!--Pantin Taj-->
+		<item offset="103" id="11298" />	<!--Pantin Tobe-->
+		<item offset="104" id="15031" />	<!--Pantin Dastanas-->
+		<item offset="105" id="16352" />	<!--Pantin Churidars-->
+		<item offset="106" id="11388" />	<!--Pantin Babouches-->
+		<item offset="107" id="16245" />	<!--Pantin Cape-->
+		<item offset="108" id="11478" />	<!--Etoile Tiara-->
+		<item offset="109" id="11305" />	<!--Etoile Casaque-->
+		<item offset="110" id="15038" />	<!--Etoile Bangles-->
+		<item offset="111" id="16360" />	<!--Etoile Tights-->
+		<item offset="112" id="11396" />	<!--Etoile Toe Shoes-->
+		<item offset="113" id="16248" />	<!--Etoile Cape-->
+		<item offset="114" id="11480" />	<!--Argute M.board-->
+		<item offset="115" id="11307" />	<!--Argute Gown-->
+		<item offset="116" id="15040" />	<!--Argute Bracers-->
+		<item offset="117" id="16362" />	<!--Argute Pants-->
+		<item offset="118" id="11398" />	<!--Argute Loafers-->
+		<item offset="119" id="15925" />	<!--Argute Belt-->
+	</slip>
+	<slip id="29318">		<!--Storage Slip 07-->
+		<item offset="0" id="15245" />	<!--War. Mask +1-->
+		<item offset="1" id="14500" />	<!--War. Lorica +1-->
+		<item offset="2" id="14909" />	<!--War. Mufflers +1-->
+		<item offset="3" id="15580" />	<!--War. Cuisses +1-->
+		<item offset="4" id="15665" />	<!--War. Calligae +1-->
+		<item offset="5" id="15246" />	<!--Mel. Crown +1-->
+		<item offset="6" id="14501" />	<!--Mel. Cyclas +1-->
+		<item offset="7" id="14910" />	<!--Mel. Gloves +1-->
+		<item offset="8" id="15581" />	<!--Mel. Hose +1-->
+		<item offset="9" id="15666" />	<!--Mel. Gaiters +1-->
+		<item offset="10" id="15247" />	<!--Clr. Cap +1-->
+		<item offset="11" id="14502" />	<!--Clr. Bliaut +1-->
+		<item offset="12" id="14911" />	<!--Clr. Mitts +1-->
+		<item offset="13" id="15582" />	<!--Clr. Pantaln. +1-->
+		<item offset="14" id="15667" />	<!--Clr. Duckbills +1-->
+		<item offset="15" id="15248" />	<!--Src. Petasos +1-->
+		<item offset="16" id="14503" />	<!--Src. Coat +1-->
+		<item offset="17" id="14912" />	<!--Src. Gloves +1-->
+		<item offset="18" id="15583" />	<!--Src. Tonban +1-->
+		<item offset="19" id="15668" />	<!--Src. Sabots +1-->
+		<item offset="20" id="15249" />	<!--Dls. Chapeau +1-->
+		<item offset="21" id="14504" />	<!--Dls. Tabard +1-->
+		<item offset="22" id="14913" />	<!--Dls. Gloves +1-->
+		<item offset="23" id="15584" />	<!--Dls. Tights +1-->
+		<item offset="24" id="15669" />	<!--Dls. Boots +1-->
+		<item offset="25" id="15250" />	<!--Asn. Bonnet +1-->
+		<item offset="26" id="14505" />	<!--Asn. Vest +1-->
+		<item offset="27" id="14914" />	<!--Asn. Armlets +1-->
+		<item offset="28" id="15585" />	<!--Asn. Culottes +1-->
+		<item offset="29" id="15670" />	<!--Asn. Poulaines +1-->
+		<item offset="30" id="15251" />	<!--Vlr. Coronet +1-->
+		<item offset="31" id="14506" />	<!--Vlr. Surcoat +1-->
+		<item offset="32" id="14915" />	<!--Vlr. Gauntlets +1-->
+		<item offset="33" id="15586" />	<!--Vlr. Breeches +1-->
+		<item offset="34" id="15671" />	<!--Vlr. Leggings +1-->
+		<item offset="35" id="15252" />	<!--Abs. Burgeonet +1-->
+		<item offset="36" id="14507" />	<!--Abs. Cuirass +1-->
+		<item offset="37" id="14916" />	<!--Abs. Gauntlets +1-->
+		<item offset="38" id="15587" />	<!--Abs. Flanchard +1-->
+		<item offset="39" id="15672" />	<!--Abs. Sollerets +1-->
+		<item offset="40" id="15253" />	<!--Mst. Helm +1-->
+		<item offset="41" id="14508" />	<!--Mst. Jackcoat +1-->
+		<item offset="42" id="14917" />	<!--Mst. Gloves +1-->
+		<item offset="43" id="15588" />	<!--Mst. Trousers +1-->
+		<item offset="44" id="15673" />	<!--Mst. Gaiters +1-->
+		<item offset="45" id="15254" />	<!--Brd. Roundlet +1-->
+		<item offset="46" id="14509" />	<!--Brd. Jstcorps +1-->
+		<item offset="47" id="14918" />	<!--Brd. Cuffs +1-->
+		<item offset="48" id="15589" />	<!--Brd. Cannions +1-->
+		<item offset="49" id="15674" />	<!--Brd. Slippers +1-->
+		<item offset="50" id="15255" />	<!--Sct. Beret +1-->
+		<item offset="51" id="14510" />	<!--Sct. Jerkin +1-->
+		<item offset="52" id="14919" />	<!--Sct. Bracers +1-->
+		<item offset="53" id="15590" />	<!--Sct. Braccae +1-->
+		<item offset="54" id="15675" />	<!--Sct. Socks +1-->
+		<item offset="55" id="15256" />	<!--Sao. Kabuto +1-->
+		<item offset="56" id="14511" />	<!--Sao. Domaru +1-->
+		<item offset="57" id="14920" />	<!--Sao. Kote +1-->
+		<item offset="58" id="15591" />	<!--Sao. Haidate +1-->
+		<item offset="59" id="15676" />	<!--Sao. Sune-Ate +1-->
+		<item offset="60" id="15257" />	<!--Kog. Hatsuburi +1-->
+		<item offset="61" id="14512" />	<!--Kog. Chainmail +1-->
+		<item offset="62" id="14921" />	<!--Kog. Tekko +1-->
+		<item offset="63" id="15592" />	<!--Kog. Hakama +1-->
+		<item offset="64" id="15677" />	<!--Kog. Kyahan +1-->
+		<item offset="65" id="15258" />	<!--Wym. Armet +1-->
+		<item offset="66" id="14513" />	<!--Wym. Mail +1-->
+		<item offset="67" id="14922" />	<!--Wym. Fng. Gnt. +1-->
+		<item offset="68" id="15593" />	<!--Wym. Brais +1-->
+		<item offset="69" id="15678" />	<!--Wym. Greaves +1-->
+		<item offset="70" id="15259" />	<!--Smn. Horn +1-->
+		<item offset="71" id="14514" />	<!--Smn. Doublet +1-->
+		<item offset="72" id="14923" />	<!--Smn. Bracers +1-->
+		<item offset="73" id="15594" />	<!--Smn. Spats +1-->
+		<item offset="74" id="15679" />	<!--Smn. Pigaches +1-->
+		<item offset="75" id="11466" />	<!--Mirage Keffiyeh +1-->
+		<item offset="76" id="11293" />	<!--Mirage Jubbah +1-->
+		<item offset="77" id="15026" />	<!--Mrg. Bazubands +1-->
+		<item offset="78" id="16347" />	<!--Mirage Shalwar +1-->
+		<item offset="79" id="11383" />	<!--Mirage Charuqs +1-->
+		<item offset="80" id="11469" />	<!--Comm. Tricorne +1-->
+		<item offset="81" id="11296" />	<!--Comm. Frac +1-->
+		<item offset="82" id="15029" />	<!--Comm. Gants +1-->
+		<item offset="83" id="16350" />	<!--Comm. Trews +1-->
+		<item offset="84" id="11386" />	<!--Comm. Bottes +1-->
+		<item offset="85" id="11472" />	<!--Pantin Taj +1-->
+		<item offset="86" id="11299" />	<!--Pantin Tobe +1-->
+		<item offset="87" id="15032" />	<!--Pantin Dastanas +1-->
+		<item offset="88" id="16353" />	<!--Ptn. Churidars +1-->
+		<item offset="89" id="11389" />	<!--Ptn. Babouches +1-->
+		<item offset="90" id="11479" />	<!--Etoile Tiara +1-->
+		<item offset="91" id="11306" />	<!--Etoile Casaque +1-->
+		<item offset="92" id="15039" />	<!--Etoile Bangles +1-->
+		<item offset="93" id="16361" />	<!--Etoile Tights +1-->
+		<item offset="94" id="11397" />	<!--Etoile Toe Shoes +1-->
+		<item offset="95" id="11481" />	<!--Argute M.board +1-->
+		<item offset="96" id="11308" />	<!--Argute Gown +1-->
+		<item offset="97" id="15041" />	<!--Argute Bracers +1-->
+		<item offset="98" id="16363" />	<!--Argute Pants +1-->
+		<item offset="99" id="11399" />	<!--Argute Loafers +1-->
+	</slip>
+	<slip id="29319">		<!--Storage Slip 08-->
+		<item offset="0" id="12008" />	<!--Ravager's Mask-->
+		<item offset="1" id="12028" />	<!--Ravager's Lorica-->
+		<item offset="2" id="12048" />	<!--Ravager's Mufflers-->
+		<item offset="3" id="12068" />	<!--Ravager's Cuisses-->
+		<item offset="4" id="12088" />	<!--Ravager's Calligae-->
+		<item offset="5" id="11591" />	<!--Ravager's Gorget-->
+		<item offset="6" id="19253" />	<!--Ravager's Orb-->
+		<item offset="7" id="12009" />	<!--Tantra Crown-->
+		<item offset="8" id="12029" />	<!--Tantra Cyclas-->
+		<item offset="9" id="12049" />	<!--Tantra Gloves-->
+		<item offset="10" id="12069" />	<!--Tantra Hose-->
+		<item offset="11" id="12089" />	<!--Tantra Gaiters-->
+		<item offset="12" id="11592" />	<!--Tantra Necklace-->
+		<item offset="13" id="19254" />	<!--Tantra Tathlum-->
+		<item offset="14" id="12010" />	<!--Orison Cap-->
+		<item offset="15" id="12030" />	<!--Orison Bliaut-->
+		<item offset="16" id="12050" />	<!--Orison Mitts-->
+		<item offset="17" id="12070" />	<!--Orison Pantaloons-->
+		<item offset="18" id="12090" />	<!--Orison Duckbills-->
+		<item offset="19" id="11615" />	<!--Orison Locket-->
+		<item offset="20" id="11554" />	<!--Orison Cape-->
+		<item offset="21" id="12011" />	<!--Goetia Petasos-->
+		<item offset="22" id="12031" />	<!--Goetia Coat-->
+		<item offset="23" id="12051" />	<!--Goetia Gloves-->
+		<item offset="24" id="12071" />	<!--Goetia Chausses-->
+		<item offset="25" id="12091" />	<!--Goetia Sabots-->
+		<item offset="26" id="11593" />	<!--Goetia Chain-->
+		<item offset="27" id="16203" />	<!--Goetia Mantle-->
+		<item offset="28" id="12012" />	<!--Estq. Chappel-->
+		<item offset="29" id="12032" />	<!--Estoqueur's Sayon-->
+		<item offset="30" id="12052" />	<!--Estq. Gantherots-->
+		<item offset="31" id="12072" />	<!--Estq. Fuseau-->
+		<item offset="32" id="12092" />	<!--Estq. Houseaux-->
+		<item offset="33" id="11594" />	<!--Estoqueur's Collar-->
+		<item offset="34" id="16204" />	<!--Estoqueur's Cape-->
+		<item offset="35" id="12013" />	<!--Raider's Bonnet-->
+		<item offset="36" id="12033" />	<!--Raider's Vest-->
+		<item offset="37" id="12053" />	<!--Raider's Armlets-->
+		<item offset="38" id="12073" />	<!--Raider's Culottes-->
+		<item offset="39" id="12093" />	<!--Raider's Poulaines-->
+		<item offset="40" id="11736" />	<!--Raider's Belt-->
+		<item offset="41" id="19260" />	<!--Raider's Bmrng.-->
+		<item offset="42" id="12014" />	<!--Creed Armet-->
+		<item offset="43" id="12034" />	<!--Creed Cuirass-->
+		<item offset="44" id="12054" />	<!--Creed Gauntlets-->
+		<item offset="45" id="12074" />	<!--Creed Cuisses-->
+		<item offset="46" id="12094" />	<!--Creed Sabatons-->
+		<item offset="47" id="11595" />	<!--Creed Collar-->
+		<item offset="48" id="11750" />	<!--Creed Baudrier-->
+		<item offset="49" id="12015" />	<!--Bale Burgeonet-->
+		<item offset="50" id="12035" />	<!--Bale Cuirass-->
+		<item offset="51" id="12055" />	<!--Bale Gauntlets-->
+		<item offset="52" id="12075" />	<!--Bale Flanchard-->
+		<item offset="53" id="12095" />	<!--Bale Sollerets-->
+		<item offset="54" id="11616" />	<!--Bale Choker-->
+		<item offset="55" id="11737" />	<!--Bale Belt-->
+		<item offset="56" id="12016" />	<!--Ferine Cabasset-->
+		<item offset="57" id="12036" />	<!--Ferine Gausape-->
+		<item offset="58" id="12056" />	<!--Ferine Manoplas-->
+		<item offset="59" id="12076" />	<!--Ferine Quijotes-->
+		<item offset="60" id="12096" />	<!--Ferine Ocreae-->
+		<item offset="61" id="11617" />	<!--Ferine Necklace-->
+		<item offset="62" id="11555" />	<!--Ferine Mantle-->
+		<item offset="63" id="12017" />	<!--Aoidos' Calot-->
+		<item offset="64" id="12037" />	<!--Aoidos' Hongreline-->
+		<item offset="65" id="12057" />	<!--Aoidos' Mnchtte.-->
+		<item offset="66" id="12077" />	<!--Aoidos' Rhingrave-->
+		<item offset="67" id="12097" />	<!--Aoidos' Cothurnes-->
+		<item offset="68" id="11618" />	<!--Aoidos' Matinee-->
+		<item offset="69" id="11738" />	<!--Aoidos' Belt-->
+		<item offset="70" id="12018" />	<!--Sylvan Gapette-->
+		<item offset="71" id="12038" />	<!--Sylvan Caban-->
+		<item offset="72" id="12058" />	<!--Syl. Glovelettes-->
+		<item offset="73" id="12078" />	<!--Sylvan Bragues-->
+		<item offset="74" id="12098" />	<!--Sylvan Bottillons-->
+		<item offset="75" id="11596" />	<!--Sylvan Scarf-->
+		<item offset="76" id="16205" />	<!--Sylvan Chlamys-->
+		<item offset="77" id="12019" />	<!--Unkai Kabuto-->
+		<item offset="78" id="12039" />	<!--Unkai Domaru-->
+		<item offset="79" id="12059" />	<!--Unkai Kote-->
+		<item offset="80" id="12079" />	<!--Unkai Haidate-->
+		<item offset="81" id="12099" />	<!--Unkai Sune-Ate-->
+		<item offset="82" id="11597" />	<!--Unkai Nodowa-->
+		<item offset="83" id="16206" />	<!--Unkai Sugemino-->
+		<item offset="84" id="12020" />	<!--Iga Zukin-->
+		<item offset="85" id="12040" />	<!--Iga Ningi-->
+		<item offset="86" id="12060" />	<!--Iga Tekko-->
+		<item offset="87" id="12080" />	<!--Iga Hakama-->
+		<item offset="88" id="12100" />	<!--Iga Kyahan-->
+		<item offset="89" id="11598" />	<!--Iga Erimaki-->
+		<item offset="90" id="16207" />	<!--Iga Dochugappa-->
+		<item offset="91" id="12021" />	<!--Lancer's Mezail-->
+		<item offset="92" id="12041" />	<!--Lncr. Plackart-->
+		<item offset="93" id="12061" />	<!--Lancer's Vambraces-->
+		<item offset="94" id="12081" />	<!--Lancer's Cuissots-->
+		<item offset="95" id="12101" />	<!--Lncr. Schynbalds-->
+		<item offset="96" id="11599" />	<!--Lancer's Torque-->
+		<item offset="97" id="16208" />	<!--Lancer's Pelerine-->
+		<item offset="98" id="12022" />	<!--Caller's Horn-->
+		<item offset="99" id="12042" />	<!--Caller's Doublet-->
+		<item offset="100" id="12062" />	<!--Caller's Bracers-->
+		<item offset="101" id="12082" />	<!--Caller's Spats-->
+		<item offset="102" id="12102" />	<!--Caller's Pigaches-->
+		<item offset="103" id="11619" />	<!--Caller's Pendant-->
+		<item offset="104" id="11739" />	<!--Caller's Sash-->
+		<item offset="105" id="12023" />	<!--Mavi Kavuk-->
+		<item offset="106" id="12043" />	<!--Mavi Mintan-->
+		<item offset="107" id="12063" />	<!--Mavi Bazubands-->
+		<item offset="108" id="12083" />	<!--Mavi Tayt-->
+		<item offset="109" id="12103" />	<!--Mavi Basmak-->
+		<item offset="110" id="11600" />	<!--Mavi Scarf-->
+		<item offset="111" id="19255" />	<!--Mavi Tathlum-->
+		<item offset="112" id="12024" />	<!--Navarch's Tricorne-->
+		<item offset="113" id="12044" />	<!--Navarch's Frac-->
+		<item offset="114" id="12064" />	<!--Navarch's Gants-->
+		<item offset="115" id="12084" />	<!--Navarch's Culottes-->
+		<item offset="116" id="12104" />	<!--Navarch's Bottes-->
+		<item offset="117" id="11601" />	<!--Navarch's Choker-->
+		<item offset="118" id="16209" />	<!--Navarch's Mantle-->
+		<item offset="119" id="12025" />	<!--Cirque Cappello-->
+		<item offset="120" id="12045" />	<!--Cirque Farsetto-->
+		<item offset="121" id="12065" />	<!--Cirque Guanti-->
+		<item offset="122" id="12085" />	<!--Cirque Pantaloni-->
+		<item offset="123" id="12105" />	<!--Cirque Scarpe-->
+		<item offset="124" id="11602" />	<!--Cirque Necklace-->
+		<item offset="125" id="11751" />	<!--Cirque Sash-->
+		<item offset="126" id="12026" />	<!--Charis Tiara-->
+		<item offset="127" id="12046" />	<!--Charis Casaque-->
+		<item offset="128" id="12066" />	<!--Charis Bangles-->
+		<item offset="129" id="12086" />	<!--Charis Tights-->
+		<item offset="130" id="12106" />	<!--Charis Toe Shoes-->
+		<item offset="131" id="11603" />	<!--Charis Necklace-->
+		<item offset="132" id="19256" />	<!--Charis Feather-->
+		<item offset="133" id="12027" />	<!--Savant's Bonnet-->
+		<item offset="134" id="12047" />	<!--Savant's Gown-->
+		<item offset="135" id="12067" />	<!--Savant's Bracers-->
+		<item offset="136" id="12087" />	<!--Savant's Pants-->
+		<item offset="137" id="12107" />	<!--Savant's Loafers-->
+		<item offset="138" id="11620" />	<!--Savant's Chain-->
+		<item offset="139" id="19247" />	<!--Savant's Treatise-->
+		<item offset="140" id="11703" />	<!--Ravager's Earring-->
+		<item offset="141" id="11704" />	<!--Tantra Earring-->
+		<item offset="142" id="11705" />	<!--Orison Earring-->
+		<item offset="143" id="11706" />	<!--Goetia Earring-->
+		<item offset="144" id="11707" />	<!--Estq. Earring-->
+		<item offset="145" id="11708" />	<!--Raider's Earring-->
+		<item offset="146" id="11709" />	<!--Creed Earring-->
+		<item offset="147" id="11710" />	<!--Bale Earring-->
+		<item offset="148" id="11711" />	<!--Ferine Earring-->
+		<item offset="149" id="11712" />	<!--Aoidos' Earring-->
+		<item offset="150" id="11713" />	<!--Sylvan Earring-->
+		<item offset="151" id="11714" />	<!--Unkai Mimikazari-->
+		<item offset="152" id="11715" />	<!--Iga Mimikazari-->
+		<item offset="153" id="11716" />	<!--Lancer's Earring-->
+		<item offset="154" id="11717" />	<!--Caller's Earring-->
+		<item offset="155" id="11718" />	<!--Mavi Earring-->
+		<item offset="156" id="11719" />	<!--Navarch's Earring-->
+		<item offset="157" id="11720" />	<!--Cirque Earring-->
+		<item offset="158" id="11721" />	<!--Charis Earring-->
+		<item offset="159" id="11722" />	<!--Savant's Earring-->
+	</slip>
+	<slip id="29320">		<!--Storage Slip 09-->
+		<item offset="0" id="11164" />	<!--Ravager's Mask +1-->
+		<item offset="1" id="11184" />	<!--Rvg. Lorica +1-->
+		<item offset="2" id="11204" />	<!--Rvg. Mufflers +1-->
+		<item offset="3" id="11224" />	<!--Rvg. Cuisses +1-->
+		<item offset="4" id="11244" />	<!--Rvg. Calligae +1-->
+		<item offset="5" id="11165" />	<!--Tantra Crown +1-->
+		<item offset="6" id="11185" />	<!--Tantra Cyclas +1-->
+		<item offset="7" id="11205" />	<!--Tantra Gloves +1-->
+		<item offset="8" id="11225" />	<!--Tantra Hose +1-->
+		<item offset="9" id="11245" />	<!--Tantra Gaiters +1-->
+		<item offset="10" id="11166" />	<!--Orison Cap +1-->
+		<item offset="11" id="11186" />	<!--Orison Bliaut +1-->
+		<item offset="12" id="11206" />	<!--Orison Mitts +1-->
+		<item offset="13" id="11226" />	<!--Orsn. Pantaln. +1-->
+		<item offset="14" id="11246" />	<!--Orsn. Duckbills +1-->
+		<item offset="15" id="11167" />	<!--Goetia Petasos +1-->
+		<item offset="16" id="11187" />	<!--Goetia Coat +1-->
+		<item offset="17" id="11207" />	<!--Goetia Gloves +1-->
+		<item offset="18" id="11227" />	<!--Goet. Chausses +1-->
+		<item offset="19" id="11247" />	<!--Goetia Sabots +1-->
+		<item offset="20" id="11168" />	<!--Estq. Chappel +1-->
+		<item offset="21" id="11188" />	<!--Estq. Sayon +1-->
+		<item offset="22" id="11208" />	<!--Estq. Ganthrt. +1-->
+		<item offset="23" id="11228" />	<!--Estqr. Fuseau +1-->
+		<item offset="24" id="11248" />	<!--Estq. Houseaux +1-->
+		<item offset="25" id="11169" />	<!--Raid. Bonnet +1-->
+		<item offset="26" id="11189" />	<!--Raider's Vest +1-->
+		<item offset="27" id="11209" />	<!--Raid. Armlets +1-->
+		<item offset="28" id="11229" />	<!--Raid. Culottes +1-->
+		<item offset="29" id="11249" />	<!--Raid. Poulaines +1-->
+		<item offset="30" id="11170" />	<!--Creed Armet +1-->
+		<item offset="31" id="11190" />	<!--Creed Cuirass +1-->
+		<item offset="32" id="11210" />	<!--Crd. Gauntlets +1-->
+		<item offset="33" id="11230" />	<!--Creed Cuisses +1-->
+		<item offset="34" id="11250" />	<!--Creed Sabatons +1-->
+		<item offset="35" id="11171" />	<!--Bale Burgeonet +1-->
+		<item offset="36" id="11191" />	<!--Bale Cuirass +1-->
+		<item offset="37" id="11211" />	<!--Bale Gauntlets +1-->
+		<item offset="38" id="11231" />	<!--Bale Flanchard +1-->
+		<item offset="39" id="11251" />	<!--Bale Sollerets +1-->
+		<item offset="40" id="11172" />	<!--Ferine Cabasset +1-->
+		<item offset="41" id="11192" />	<!--Ferine Gausape +1-->
+		<item offset="42" id="11212" />	<!--Frn. Manoplas +1-->
+		<item offset="43" id="11232" />	<!--Ferine Quijotes +1-->
+		<item offset="44" id="11252" />	<!--Ferine Ocreae +1-->
+		<item offset="45" id="11173" />	<!--Aoidos' Calot +1-->
+		<item offset="46" id="11193" />	<!--Aoidos' Hngrln. +1-->
+		<item offset="47" id="11213" />	<!--Ad. Mnchtte. +1-->
+		<item offset="48" id="11233" />	<!--Aoidos' Rhing. +1-->
+		<item offset="49" id="11253" />	<!--Aoidos' Cothrn. +1-->
+		<item offset="50" id="11174" />	<!--Sylvan Gapette +1-->
+		<item offset="51" id="11194" />	<!--Sylvan Caban +1-->
+		<item offset="52" id="11214" />	<!--Syl. Glvltte. +1-->
+		<item offset="53" id="11234" />	<!--Sylvan Bragues +1-->
+		<item offset="54" id="11254" />	<!--Sylvan Bottln. +1-->
+		<item offset="55" id="11175" />	<!--Unkai Kabuto +1-->
+		<item offset="56" id="11195" />	<!--Unkai Domaru +1-->
+		<item offset="57" id="11215" />	<!--Unkai Kote +1-->
+		<item offset="58" id="11235" />	<!--Unkai Haidate +1-->
+		<item offset="59" id="11255" />	<!--Unkai Sune-Ate +1-->
+		<item offset="60" id="11176" />	<!--Iga Zukin +1-->
+		<item offset="61" id="11196" />	<!--Iga Ningi +1-->
+		<item offset="62" id="11216" />	<!--Iga Tekko +1-->
+		<item offset="63" id="11236" />	<!--Iga Hakama +1-->
+		<item offset="64" id="11256" />	<!--Iga Kyahan +1-->
+		<item offset="65" id="11177" />	<!--Lancer's Mezail +1-->
+		<item offset="66" id="11197" />	<!--Lncr. Plackart +1-->
+		<item offset="67" id="11217" />	<!--Lncr. Vmbrc. +1-->
+		<item offset="68" id="11237" />	<!--Lncr. Cuissots +1-->
+		<item offset="69" id="11257" />	<!--Lncr. Schynbld. +1-->
+		<item offset="70" id="11178" />	<!--Caller's Horn +1-->
+		<item offset="71" id="11198" />	<!--Caller's Doublet +1-->
+		<item offset="72" id="11218" />	<!--Caller's Bracers +1-->
+		<item offset="73" id="11238" />	<!--Caller's Spats +1-->
+		<item offset="74" id="11258" />	<!--Caller's Pgch. +1-->
+		<item offset="75" id="11179" />	<!--Mavi Kavuk +1-->
+		<item offset="76" id="11199" />	<!--Mavi Mintan +1-->
+		<item offset="77" id="11219" />	<!--Mv. Bazubands +1-->
+		<item offset="78" id="11239" />	<!--Mavi Tayt +1-->
+		<item offset="79" id="11259" />	<!--Mavi Basmak +1-->
+		<item offset="80" id="11180" />	<!--Nvrch. Tricorne +1-->
+		<item offset="81" id="11200" />	<!--Navarch's Frac +1-->
+		<item offset="82" id="11220" />	<!--Nvrch. Gants +1-->
+		<item offset="83" id="11240" />	<!--Nvrch. Culottes +1-->
+		<item offset="84" id="11260" />	<!--Nvrch. Bottes +1-->
+		<item offset="85" id="11181" />	<!--Cirque Cappello +1-->
+		<item offset="86" id="11201" />	<!--Cirque Farsetto +1-->
+		<item offset="87" id="11221" />	<!--Cirque Guanti +1-->
+		<item offset="88" id="11241" />	<!--Cirq. Pantaloni +1-->
+		<item offset="89" id="11261" />	<!--Cirque Scarpe +1-->
+		<item offset="90" id="11182" />	<!--Charis Tiara +1-->
+		<item offset="91" id="11202" />	<!--Charis Casaque +1-->
+		<item offset="92" id="11222" />	<!--Charis Bangles +1-->
+		<item offset="93" id="11242" />	<!--Charis Tights +1-->
+		<item offset="94" id="11262" />	<!--Charis Toe Shoes +1-->
+		<item offset="95" id="11183" />	<!--Svnt. Bonnet +1-->
+		<item offset="96" id="11203" />	<!--Savant's Gown +1-->
+		<item offset="97" id="11223" />	<!--Svnt. Bracers +1-->
+		<item offset="98" id="11243" />	<!--Savant's Pants +1-->
+		<item offset="99" id="11263" />	<!--Svnt. Loafers +1-->
+	</slip>
+	<slip id="29321">		<!--Storage Slip 10-->
+		<item offset="0" id="11064" />	<!--Ravager's Mask +2-->
+		<item offset="1" id="11084" />	<!--Rvg. Lorica +2-->
+		<item offset="2" id="11104" />	<!--Rvg. Mufflers +2-->
+		<item offset="3" id="11124" />	<!--Rvg. Cuisses +2-->
+		<item offset="4" id="11144" />	<!--Rvg. Calligae +2-->
+		<item offset="5" id="11065" />	<!--Tantra Crown +2-->
+		<item offset="6" id="11085" />	<!--Tantra Cyclas +2-->
+		<item offset="7" id="11105" />	<!--Tantra Gloves +2-->
+		<item offset="8" id="11125" />	<!--Tantra Hose +2-->
+		<item offset="9" id="11145" />	<!--Tantra Gaiters +2-->
+		<item offset="10" id="11066" />	<!--Orison Cap +2-->
+		<item offset="11" id="11086" />	<!--Orison Bliaut +2-->
+		<item offset="12" id="11106" />	<!--Orison Mitts +2-->
+		<item offset="13" id="11126" />	<!--Orsn. Pantaln. +2-->
+		<item offset="14" id="11146" />	<!--Orsn. Duckbills +2-->
+		<item offset="15" id="11067" />	<!--Goetia Petasos +2-->
+		<item offset="16" id="11087" />	<!--Goetia Coat +2-->
+		<item offset="17" id="11107" />	<!--Goetia Gloves +2-->
+		<item offset="18" id="11127" />	<!--Goet. Chausses +2-->
+		<item offset="19" id="11147" />	<!--Goetia Sabots +2-->
+		<item offset="20" id="11068" />	<!--Estq. Chappel +2-->
+		<item offset="21" id="11088" />	<!--Estq. Sayon +2-->
+		<item offset="22" id="11108" />	<!--Estq. Ganthrt. +2-->
+		<item offset="23" id="11128" />	<!--Estqr. Fuseau +2-->
+		<item offset="24" id="11148" />	<!--Estq. Houseaux +2-->
+		<item offset="25" id="11069" />	<!--Raid. Bonnet +2-->
+		<item offset="26" id="11089" />	<!--Raider's Vest +2-->
+		<item offset="27" id="11109" />	<!--Raid. Armlets +2-->
+		<item offset="28" id="11129" />	<!--Raid. Culottes +2-->
+		<item offset="29" id="11149" />	<!--Raid. Poulaines +2-->
+		<item offset="30" id="11070" />	<!--Creed Armet +2-->
+		<item offset="31" id="11090" />	<!--Creed Cuirass +2-->
+		<item offset="32" id="11110" />	<!--Crd. Gauntlets +2-->
+		<item offset="33" id="11130" />	<!--Creed Cuisses +2-->
+		<item offset="34" id="11150" />	<!--Creed Sabatons +2-->
+		<item offset="35" id="11071" />	<!--Bale Burgeonet +2-->
+		<item offset="36" id="11091" />	<!--Bale Cuirass +2-->
+		<item offset="37" id="11111" />	<!--Bale Gauntlets +2-->
+		<item offset="38" id="11131" />	<!--Bale Flanchard +2-->
+		<item offset="39" id="11151" />	<!--Bale Sollerets +2-->
+		<item offset="40" id="11072" />	<!--Ferine Cabasset +2-->
+		<item offset="41" id="11092" />	<!--Ferine Gausape +2-->
+		<item offset="42" id="11112" />	<!--Frn. Manoplas +2-->
+		<item offset="43" id="11132" />	<!--Ferine Quijotes +2-->
+		<item offset="44" id="11152" />	<!--Ferine Ocreae +2-->
+		<item offset="45" id="11073" />	<!--Aoidos' Calot +2-->
+		<item offset="46" id="11093" />	<!--Aoidos' Hngrln. +2-->
+		<item offset="47" id="11113" />	<!--Ad. Mnchtte. +2-->
+		<item offset="48" id="11133" />	<!--Aoidos' Rhing. +2-->
+		<item offset="49" id="11153" />	<!--Aoidos' Cothrn. +2-->
+		<item offset="50" id="11074" />	<!--Sylvan Gapette +2-->
+		<item offset="51" id="11094" />	<!--Sylvan Caban +2-->
+		<item offset="52" id="11114" />	<!--Syl. Glvltte. +2-->
+		<item offset="53" id="11134" />	<!--Sylvan Bragues +2-->
+		<item offset="54" id="11154" />	<!--Sylvan Bottln. +2-->
+		<item offset="55" id="11075" />	<!--Unkai Kabuto +2-->
+		<item offset="56" id="11095" />	<!--Unkai Domaru +2-->
+		<item offset="57" id="11115" />	<!--Unkai Kote +2-->
+		<item offset="58" id="11135" />	<!--Unkai Haidate +2-->
+		<item offset="59" id="11155" />	<!--Unkai Sune-Ate +2-->
+		<item offset="60" id="11076" />	<!--Iga Zukin +2-->
+		<item offset="61" id="11096" />	<!--Iga Ningi +2-->
+		<item offset="62" id="11116" />	<!--Iga Tekko +2-->
+		<item offset="63" id="11136" />	<!--Iga Hakama +2-->
+		<item offset="64" id="11156" />	<!--Iga Kyahan +2-->
+		<item offset="65" id="11077" />	<!--Lancer's Mezail +2-->
+		<item offset="66" id="11097" />	<!--Lncr. Plackart +2-->
+		<item offset="67" id="11117" />	<!--Lncr. Vmbrc. +2-->
+		<item offset="68" id="11137" />	<!--Lncr. Cuissots +2-->
+		<item offset="69" id="11157" />	<!--Lncr. Schynbld. +2-->
+		<item offset="70" id="11078" />	<!--Caller's Horn +2-->
+		<item offset="71" id="11098" />	<!--Call. Doublet +2-->
+		<item offset="72" id="11118" />	<!--Call. Bracers +2-->
+		<item offset="73" id="11138" />	<!--Caller's Spats +2-->
+		<item offset="74" id="11158" />	<!--Caller's Pgch. +2-->
+		<item offset="75" id="11079" />	<!--Mavi Kavuk +2-->
+		<item offset="76" id="11099" />	<!--Mavi Mintan +2-->
+		<item offset="77" id="11119" />	<!--Mv. Bazubands +2-->
+		<item offset="78" id="11139" />	<!--Mavi Tayt +2-->
+		<item offset="79" id="11159" />	<!--Mavi Basmak +2-->
+		<item offset="80" id="11080" />	<!--Nvrch. Tricorne +2-->
+		<item offset="81" id="11100" />	<!--Nvrch. Frac +2-->
+		<item offset="82" id="11120" />	<!--Nvrch. Gants +2-->
+		<item offset="83" id="11140" />	<!--Nvrch. Culottes +2-->
+		<item offset="84" id="11160" />	<!--Nvrch. Bottes +2-->
+		<item offset="85" id="11081" />	<!--Cirque Cappello +2-->
+		<item offset="86" id="11101" />	<!--Cirque Farsetto +2-->
+		<item offset="87" id="11121" />	<!--Cirque Guanti +2-->
+		<item offset="88" id="11141" />	<!--Cirq. Pantaloni +2-->
+		<item offset="89" id="11161" />	<!--Cirque Scarpe +2-->
+		<item offset="90" id="11082" />	<!--Charis Tiara +2-->
+		<item offset="91" id="11102" />	<!--Charis Casaque +2-->
+		<item offset="92" id="11122" />	<!--Charis Bangles +2-->
+		<item offset="93" id="11142" />	<!--Charis Tights +2-->
+		<item offset="94" id="11162" />	<!--Charis Toe Shoes +2-->
+		<item offset="95" id="11083" />	<!--Svnt. Bonnet +2-->
+		<item offset="96" id="11103" />	<!--Savant's Gown +2-->
+		<item offset="97" id="11123" />	<!--Svnt. Bracers +2-->
+		<item offset="98" id="11143" />	<!--Savant's Pants +2-->
+		<item offset="99" id="11163" />	<!--Svnt. Loafers +2-->
+	</slip>
+	<slip id="29322">		<!--Storage Slip 11-->
+		<item offset="0" id="15297" />	<!--Rabbit Belt-->
+		<item offset="1" id="15298" />	<!--Worm Belt-->
+		<item offset="2" id="15299" />	<!--Mandragora Belt-->
+		<item offset="3" id="15919" />	<!--Drover's Belt-->
+		<item offset="4" id="15929" />	<!--Goblin Belt-->
+		<item offset="5" id="15921" />	<!--Detonator Belt-->
+		<item offset="6" id="18871" />	<!--Kitty Rod-->
+		<item offset="7" id="16273" />	<!--Pullus Torque-->
+		<item offset="8" id="18166" />	<!--Happy Egg-->
+		<item offset="9" id="18167" />	<!--Fortune Egg-->
+		<item offset="10" id="18256" />	<!--Orphic Egg-->
+		<item offset="11" id="13216" />	<!--Gold Mog. Belt-->
+		<item offset="12" id="13217" />	<!--Silver Mog. Belt-->
+		<item offset="13" id="13218" />	<!--Bronze Mog. Belt-->
+		<item offset="14" id="15455" />	<!--Red Sash-->
+		<item offset="15" id="15456" />	<!--Dash Sash-->
+		<item offset="16" id="181" />	<!--San d'Orian Flag-->
+		<item offset="17" id="182" />	<!--Bastokan Flag-->
+		<item offset="18" id="183" />	<!--Windurstian Flag-->
+		<item offset="19" id="184" />	<!--Jeunoan Flag-->
+		<item offset="20" id="129" />	<!--Imperial Standard-->
+		<item offset="21" id="11499" />	<!--Trainee's Specs.-->
+		<item offset="22" id="18502" />	<!--Trainee Axe-->
+		<item offset="23" id="18855" />	<!--Trainee Hammer-->
+		<item offset="24" id="19274" />	<!--Trainee Burin-->
+		<item offset="25" id="18763" />	<!--Trainee Scissors-->
+		<item offset="26" id="19110" />	<!--Trainee's Needle-->
+		<item offset="27" id="15008" />	<!--Trainee Gloves-->
+		<item offset="28" id="17764" />	<!--Trainee Sword-->
+		<item offset="29" id="19101" />	<!--Trainee Knife-->
+		<item offset="30" id="365" />	<!--Poele Classique-->
+		<item offset="31" id="366" />	<!--Kanonenofen-->
+		<item offset="32" id="367" />	<!--Pot Topper-->
+		<item offset="33" id="15860" />	<!--Gyokuto Obi-->
+		<item offset="34" id="272" />	<!--A.Angel HM Stat.-->
+		<item offset="35" id="273" />	<!--A.Angel EV Stat.-->
+		<item offset="36" id="274" />	<!--A.Angel TT Stat.-->
+		<item offset="37" id="275" />	<!--A.Angel MR Stat.-->
+		<item offset="38" id="276" />	<!--A.Angel GK Stat.-->
+		<item offset="39" id="11853" />	<!--Novennial Coat-->
+		<item offset="40" id="11956" />	<!--Novennial Hose-->
+		<item offset="41" id="11854" />	<!--Novennial Dress-->
+		<item offset="42" id="11957" />	<!--Novennial Boots-->
+		<item offset="43" id="11811" />	<!--Destrier Beret-->
+		<item offset="44" id="11812" />	<!--Charity Cap-->
+		<item offset="45" id="11861" />	<!--Hikogami Yukata-->
+		<item offset="46" id="11862" />	<!--Himegami Yukata-->
+		<item offset="47" id="3676" />	<!--Celestial Globe-->
+		<item offset="48" id="18879" />	<!--Rounsey Wand-->
+		<item offset="49" id="3647" />	<!--Spook-a-Swirl-->
+		<item offset="50" id="3648" />	<!--Choc. Grumpkin-->
+		<item offset="51" id="3649" />	<!--Harvest Horror-->
+		<item offset="52" id="3677" />	<!--Spinet-->
+		<item offset="53" id="18880" />	<!--Maestro's Baton-->
+		<item offset="54" id="18863" />	<!--Dream Bell-->
+		<item offset="55" id="18864" />	<!--Dream Bell +1-->
+		<item offset="56" id="15178" />	<!--Dream Hat-->
+		<item offset="57" id="14519" />	<!--Dream Robe-->
+		<item offset="58" id="10382" />	<!--Dream Mittens-->
+		<item offset="59" id="11965" />	<!--Dream Trousers-->
+		<item offset="60" id="11967" />	<!--Dream Pants-->
+		<item offset="61" id="15752" />	<!--Dream Boots-->
+		<item offset="62" id="15179" />	<!--Dream Hat +1-->
+		<item offset="63" id="14520" />	<!--Dream Robe +1-->
+		<item offset="64" id="10383" />	<!--Dream Mittens +1-->
+		<item offset="65" id="11966" />	<!--Dream Trousers +1-->
+		<item offset="66" id="11968" />	<!--Dream Pants +1-->
+		<item offset="67" id="15753" />	<!--Dream Boots +1-->
+		<item offset="68" id="10875" />	<!--Snowman Cap-->
+		<item offset="69" id="3619" />	<!--Cour. des Etoiles-->
+		<item offset="70" id="3620" />	<!--Silberkranz-->
+		<item offset="71" id="3621" />	<!--Leafberry Wreath-->
+		<item offset="72" id="3650" />	<!--Prinseggstarta-->
+		<item offset="73" id="3652" />	<!--Memorial Cake-->
+		<item offset="74" id="10430" />	<!--Decennial Crown-->
+		<item offset="75" id="10251" />	<!--Decennial Coat-->
+		<item offset="76" id="10593" />	<!--Decennial Tights-->
+		<item offset="77" id="10431" />	<!--Decennial Tiara-->
+		<item offset="78" id="10252" />	<!--Decennial Dress-->
+		<item offset="79" id="10594" />	<!--Decennial Hose-->
+		<item offset="80" id="10432" />	<!--Decennial Crown +1-->
+		<item offset="81" id="10253" />	<!--Decennial Coat +1-->
+		<item offset="82" id="10595" />	<!--Decennial Tights +1-->
+		<item offset="83" id="10433" />	<!--Decennial Tiara +1-->
+		<item offset="84" id="10254" />	<!--Decennial Dress +1-->
+		<item offset="85" id="10596" />	<!--Decennial Hose +1-->
+		<item offset="86" id="10429" />	<!--Moogle Masque-->
+		<item offset="87" id="10250" />	<!--Moogle Suit-->
+		<item offset="88" id="17031" />	<!--Shell Scepter-->
+		<item offset="89" id="17032" />	<!--Gobbie Gavel-->
+		<item offset="90" id="10807" />	<!--Mandraguard-->
+		<item offset="91" id="18881" />	<!--Melomane Mallet-->
+		<item offset="92" id="10256" />	<!--Marine Gilet-->
+		<item offset="93" id="10330" />	<!--Marine Boxers-->
+		<item offset="94" id="10257" />	<!--Marine Top-->
+		<item offset="95" id="10331" />	<!--Marine Shorts-->
+		<item offset="96" id="10258" />	<!--Woodsy Gilet-->
+		<item offset="97" id="10332" />	<!--Woodsy Boxers-->
+		<item offset="98" id="10259" />	<!--Woodsy Top-->
+		<item offset="99" id="10333" />	<!--Woodsy Shorts-->
+		<item offset="100" id="10260" />	<!--Creek Maillot-->
+		<item offset="101" id="10334" />	<!--Creek Boxers-->
+		<item offset="102" id="10261" />	<!--Creek Top-->
+		<item offset="103" id="10335" />	<!--Creek Shorts-->
+		<item offset="104" id="10262" />	<!--River Top-->
+		<item offset="105" id="10336" />	<!--River Shorts-->
+		<item offset="106" id="10263" />	<!--Dune Gilet-->
+		<item offset="107" id="10337" />	<!--Dune Boxers-->
+		<item offset="108" id="10264" />	<!--Marine Gilet +1-->
+		<item offset="109" id="10338" />	<!--Marine Boxers +1-->
+		<item offset="110" id="10265" />	<!--Marine Top +1-->
+		<item offset="111" id="10339" />	<!--Marine Shorts +1-->
+		<item offset="112" id="10266" />	<!--Woodsy Gilet +1-->
+		<item offset="113" id="10340" />	<!--Woodsy Boxers +1-->
+		<item offset="114" id="10267" />	<!--Woodsy Top +1-->
+		<item offset="115" id="10341" />	<!--Woodsy Shorts +1-->
+		<item offset="116" id="10268" />	<!--Creek Maillot +1-->
+		<item offset="117" id="10342" />	<!--Creek Boxers +1-->
+		<item offset="118" id="10269" />	<!--Creek Top +1-->
+		<item offset="119" id="10343" />	<!--Creek Shorts +1-->
+		<item offset="120" id="10270" />	<!--River Top +1-->
+		<item offset="121" id="10344" />	<!--River Shorts +1-->
+		<item offset="122" id="10271" />	<!--Dune Gilet +1-->
+		<item offset="123" id="10345" />	<!--Dune Boxers +1-->
+		<item offset="124" id="10446" />	<!--Ahriman Cap-->
+		<item offset="125" id="10447" />	<!--Pyracmon Cap-->
+		<item offset="126" id="426" />	<!--Orchestrion-->
+		<item offset="127" id="10808" />	<!--Janus Guard-->
+		<item offset="128" id="3654" />	<!--Tender Bouquet-->
+		<item offset="129" id="265" />	<!--Adamant. Statue-->
+		<item offset="130" id="266" />	<!--Behemoth Statue-->
+		<item offset="131" id="267" />	<!--Fafnir Statue-->
+		<item offset="132" id="269" />	<!--S. Lord Statue-->
+		<item offset="133" id="270" />	<!--Odin Statue-->
+		<item offset="134" id="271" />	<!--Alexander Statue-->
+		<item offset="135" id="18464" />	<!--Ark Tachi-->
+		<item offset="136" id="18545" />	<!--Ark Tabar-->
+		<item offset="137" id="18563" />	<!--Ark Scythe-->
+		<item offset="138" id="18912" />	<!--Ark Saber-->
+		<item offset="139" id="18913" />	<!--Ark Sword-->
+		<item offset="140" id="10293" />	<!--Chocobo Shirt-->
+		<item offset="141" id="10809" />	<!--Moogle Guard-->
+		<item offset="142" id="10810" />	<!--Moogle Guard +1-->
+		<item offset="143" id="10811" />	<!--Chocobo Shield-->
+		<item offset="144" id="10812" />	<!--Choco. Shield +1-->
+		<item offset="145" id="27803" />	<!--Rustic Maillot-->
+		<item offset="146" id="28086" />	<!--Rustic Trunks-->
+		<item offset="147" id="27804" />	<!--Shoal Maillot-->
+		<item offset="148" id="28087" />	<!--Shoal Trunks-->
+		<item offset="149" id="27805" />	<!--Rustic Maillot +1-->
+		<item offset="150" id="28088" />	<!--Rustic Trunks +1-->
+		<item offset="151" id="27806" />	<!--Shoal Maillot +1-->
+		<item offset="152" id="28089" />	<!--Shoal Trunks +1-->
+		<item offset="153" id="27765" />	<!--Chocobo Masque-->
+		<item offset="154" id="27911" />	<!--Chocobo Suit-->
+		<item offset="155" id="27760" />	<!--Chocobo Masque +1-->
+		<item offset="156" id="27906" />	<!--Chocobo Suit +1-->
+		<item offset="157" id="27759" />	<!--Korrigan Beret-->
+		<item offset="158" id="28661" />	<!--Glinting Shield-->
+		<item offset="159" id="286" />	<!--Nanaa Mihgo Statue-->
+		<item offset="160" id="27757" />	<!--Bomb Masque-->
+		<item offset="161" id="27758" />	<!--Bomb Masque +1-->
+		<item offset="162" id="287" />	<!--Nanaa Mihgo S. II-->
+		<item offset="163" id="27899" />	<!--Alliance Shirt-->
+		<item offset="164" id="28185" />	<!--Alliance Pants-->
+		<item offset="165" id="28324" />	<!--Alliance Boots-->
+		<item offset="166" id="27898" />	<!--Alliance Shirt +1-->
+		<item offset="167" id="28655" />	<!--Slime Shield-->
+		<item offset="168" id="27756" />	<!--Slime Cap-->
+		<item offset="169" id="28511" />	<!--Slime Earring-->
+		<item offset="170" id="21118" />	<!--G. Spriggan Club-->
+		<item offset="171" id="27902" />	<!--G. Spriggan Coat-->
+		<item offset="172" id="100" />	<!--Okadomatsu-->
+		<item offset="173" id="21117" />	<!--Hagoita-->
+		<item offset="174" id="87" />	<!--Kadomatsu-->
+		<item offset="175" id="20953" />	<!--Escritorio-->
+		<item offset="176" id="21280" />	<!--Decazoom Mk-XI-->
+		<item offset="177" id="28652" />	<!--Hatchling Shield-->
+		<item offset="178" id="28650" />	<!--She-Slime Shield-->
+		<item offset="179" id="27726" />	<!--She-Slime Hat-->
+		<item offset="180" id="28509" />	<!--She-Slime Earring-->
+		<item offset="181" id="28651" />	<!--Metal Slime Shield-->
+		<item offset="182" id="27727" />	<!--Metal Slime Hat-->
+		<item offset="183" id="28510" />	<!--M. Slime Earring-->
+		<item offset="184" id="27872" />	<!--P. Spriggan Coat-->
+		<item offset="185" id="21113" />	<!--P. Sprig. Club-->
+		<item offset="186" id="27873" />	<!--R. Spriggan Coat-->
+		<item offset="187" id="21114" />	<!--R. Sprig. Club-->
+		<item offset="188" id="20532" />	<!--Worm Feelers-->
+		<item offset="189" id="20533" />	<!--Worm Feelers +1-->
+		<item offset="190" id="27717" />	<!--Worm Masque-->
+		<item offset="191" id="27718" />	<!--Worm Masque +1-->
+	</slip>
+	<slip id="29323">		<!--Storage Slip 12-->
+		<item offset="0" id="2033" />	<!--War. Mask -1-->
+		<item offset="1" id="2034" />	<!--War. Lorica -1-->
+		<item offset="2" id="2035" />	<!--War. Mufflers -1-->
+		<item offset="3" id="2036" />	<!--War. Cuisses -1-->
+		<item offset="4" id="2037" />	<!--War. Calligae -1-->
+		<item offset="5" id="2038" />	<!--Mel. Crown -1-->
+		<item offset="6" id="2039" />	<!--Mel. Cyclas -1-->
+		<item offset="7" id="2040" />	<!--Mel. Gloves -1-->
+		<item offset="8" id="2041" />	<!--Mel. Hose -1-->
+		<item offset="9" id="2042" />	<!--Mel. Gaiters -1-->
+		<item offset="10" id="2043" />	<!--Clr. Cap -1-->
+		<item offset="11" id="2044" />	<!--Clr. Bliaut -1-->
+		<item offset="12" id="2045" />	<!--Clr. Mitts -1-->
+		<item offset="13" id="2046" />	<!--Clr. Pantaln. -1-->
+		<item offset="14" id="2047" />	<!--Clr. Duckbills -1-->
+		<item offset="15" id="2048" />	<!--Src. Petasos -1-->
+		<item offset="16" id="2049" />	<!--Src. Coat -1-->
+		<item offset="17" id="2050" />	<!--Src. Gloves -1-->
+		<item offset="18" id="2051" />	<!--Src. Tonban -1-->
+		<item offset="19" id="2052" />	<!--Src. Sabots -1-->
+		<item offset="20" id="2053" />	<!--Dls. Chapeau -1-->
+		<item offset="21" id="2054" />	<!--Dls. Tabard -1-->
+		<item offset="22" id="2055" />	<!--Dls. Gloves -1-->
+		<item offset="23" id="2056" />	<!--Dls. Tights -1-->
+		<item offset="24" id="2057" />	<!--Dls. Boots -1-->
+		<item offset="25" id="2058" />	<!--Asn. Bonnet -1-->
+		<item offset="26" id="2059" />	<!--Asn. Vest -1-->
+		<item offset="27" id="2060" />	<!--Asn. Armlets -1-->
+		<item offset="28" id="2061" />	<!--Asn. Culotte -1-->
+		<item offset="29" id="2062" />	<!--Asn. Poulaines -1-->
+		<item offset="30" id="2063" />	<!--Vlr. Coronet -1-->
+		<item offset="31" id="2064" />	<!--Vlr. Surcoat -1-->
+		<item offset="32" id="2065" />	<!--Vlr. Gauntlets -1-->
+		<item offset="33" id="2066" />	<!--Vlr. Breeches -1-->
+		<item offset="34" id="2067" />	<!--Vlr. Leggings -1-->
+		<item offset="35" id="2068" />	<!--Abs. Burgeonet -1-->
+		<item offset="36" id="2069" />	<!--Abs. Cuirass -1-->
+		<item offset="37" id="2070" />	<!--Abs. Gauntlets -1-->
+		<item offset="38" id="2071" />	<!--Abs. Flanchard -1-->
+		<item offset="39" id="2072" />	<!--Abs. Sollerets -1-->
+		<item offset="40" id="2073" />	<!--Mst. Helm -1-->
+		<item offset="41" id="2074" />	<!--Mst. Jackcoat -1-->
+		<item offset="42" id="2075" />	<!--Mst. Gloves -1-->
+		<item offset="43" id="2076" />	<!--Mst. Trousers -1-->
+		<item offset="44" id="2077" />	<!--Mst. Gaiters -1-->
+		<item offset="45" id="2078" />	<!--Brd. Roundlet -1-->
+		<item offset="46" id="2079" />	<!--Brd. Jstcorps -1-->
+		<item offset="47" id="2080" />	<!--Brd. Cuffs -1-->
+		<item offset="48" id="2081" />	<!--Brd. Cannions -1-->
+		<item offset="49" id="2082" />	<!--Brd. Slippers -1-->
+		<item offset="50" id="2083" />	<!--Sct. Beret -1-->
+		<item offset="51" id="2084" />	<!--Sct. Jerkin -1-->
+		<item offset="52" id="2085" />	<!--Sct. Bracers -1-->
+		<item offset="53" id="2086" />	<!--Sct. Braccae -1-->
+		<item offset="54" id="2087" />	<!--Sct. Socks -1-->
+		<item offset="55" id="2088" />	<!--Sao. Kabuto -1-->
+		<item offset="56" id="2089" />	<!--Sao. Domaru -1-->
+		<item offset="57" id="2090" />	<!--Sao. Kote -1-->
+		<item offset="58" id="2091" />	<!--Sao. Haidate -1-->
+		<item offset="59" id="2092" />	<!--Sao. Sune-Ate -1-->
+		<item offset="60" id="2093" />	<!--Kog. Hatsuburi -1-->
+		<item offset="61" id="2094" />	<!--Kog. Chainmail -1-->
+		<item offset="62" id="2095" />	<!--Kog. Tekko -1-->
+		<item offset="63" id="2096" />	<!--Kog. Hakama -1-->
+		<item offset="64" id="2097" />	<!--Kog. Kyahan -1-->
+		<item offset="65" id="2098" />	<!--Wym. Armet -1-->
+		<item offset="66" id="2099" />	<!--Wym. Mail -1-->
+		<item offset="67" id="2100" />	<!--Wym. Fng. Gnt. -1-->
+		<item offset="68" id="2101" />	<!--Wym. Brais -1-->
+		<item offset="69" id="2102" />	<!--Wym. Greaves -1-->
+		<item offset="70" id="2103" />	<!--Smn. Horn -1-->
+		<item offset="71" id="2104" />	<!--Smn. Doublet -1-->
+		<item offset="72" id="2105" />	<!--Smn. Bracers -1-->
+		<item offset="73" id="2106" />	<!--Smn. Spats -1-->
+		<item offset="74" id="2107" />	<!--Smn. Pigaches -1-->
+		<item offset="75" id="2662" />	<!--Mirage Keffiyeh -1-->
+		<item offset="76" id="2663" />	<!--Mirage Jubbah -1-->
+		<item offset="77" id="2664" />	<!--Mrg. Bazubands -1-->
+		<item offset="78" id="2665" />	<!--Mirage Shalwar -1-->
+		<item offset="79" id="2666" />	<!--Mirage Charuqs -1-->
+		<item offset="80" id="2667" />	<!--Comm. Tricorne -1-->
+		<item offset="81" id="2668" />	<!--Comm. Frac -1-->
+		<item offset="82" id="2669" />	<!--Comm. Gants -1-->
+		<item offset="83" id="2670" />	<!--Comm. Trews -1-->
+		<item offset="84" id="2671" />	<!--Comm. Bottes -1-->
+		<item offset="85" id="2672" />	<!--Pantin Taj -1-->
+		<item offset="86" id="2673" />	<!--Pantin Tobe -1-->
+		<item offset="87" id="2674" />	<!--Ptn. Dastanas -1-->
+		<item offset="88" id="2675" />	<!--Ptn. Churidars -1-->
+		<item offset="89" id="2676" />	<!--Ptn. Babouches -1-->
+		<item offset="90" id="2718" />	<!--Etoile Tiara -1-->
+		<item offset="91" id="2719" />	<!--Etoile Casaque -1-->
+		<item offset="92" id="2720" />	<!--Etoile Bangles -1-->
+		<item offset="93" id="2721" />	<!--Etoile Tights -1-->
+		<item offset="94" id="2722" />	<!--Etoile Toe Shoes -1-->
+		<item offset="95" id="2723" />	<!--Argute M.board -1-->
+		<item offset="96" id="2724" />	<!--Argute Gown -1-->
+		<item offset="97" id="2725" />	<!--Argute Bracers -1-->
+		<item offset="98" id="2726" />	<!--Argute Pants -1-->
+		<item offset="99" id="2727" />	<!--Argute Loafers -1-->
+	</slip>
+	<slip id="29324">		<!--Storage Slip 13-->
+		<item offset="0" id="10650" />	<!--War. Mask +2-->
+		<item offset="1" id="10670" />	<!--War. Lorica +2-->
+		<item offset="2" id="10690" />	<!--War. Mufflers +2-->
+		<item offset="3" id="10710" />	<!--War. Cuisses +2-->
+		<item offset="4" id="10730" />	<!--War. Calligae +2-->
+		<item offset="5" id="10651" />	<!--Mel. Crown +2-->
+		<item offset="6" id="10671" />	<!--Mel. Cyclas +2-->
+		<item offset="7" id="10691" />	<!--Mel. Gloves +2-->
+		<item offset="8" id="10711" />	<!--Mel. Hose +2-->
+		<item offset="9" id="10731" />	<!--Mel. Gaiters +2-->
+		<item offset="10" id="10652" />	<!--Clr. Cap +2-->
+		<item offset="11" id="10672" />	<!--Clr. Bliaut +2-->
+		<item offset="12" id="10692" />	<!--Clr. Mitts +2-->
+		<item offset="13" id="10712" />	<!--Clr. Pantaln. +2-->
+		<item offset="14" id="10732" />	<!--Clr. Duckbills +2-->
+		<item offset="15" id="10653" />	<!--Src. Petasos +2-->
+		<item offset="16" id="10673" />	<!--Src. Coat +2-->
+		<item offset="17" id="10693" />	<!--Src. Gloves +2-->
+		<item offset="18" id="10713" />	<!--Src. Tonban +2-->
+		<item offset="19" id="10733" />	<!--Src. Sabots +2-->
+		<item offset="20" id="10654" />	<!--Dls. Chapeau +2-->
+		<item offset="21" id="10674" />	<!--Dls. Tabard +2-->
+		<item offset="22" id="10694" />	<!--Dls. Gloves +2-->
+		<item offset="23" id="10714" />	<!--Dls. Tights +2-->
+		<item offset="24" id="10734" />	<!--Dls. Boots +2-->
+		<item offset="25" id="10655" />	<!--Asn. Bonnet +2-->
+		<item offset="26" id="10675" />	<!--Asn. Vest +2-->
+		<item offset="27" id="10695" />	<!--Asn. Armlets +2-->
+		<item offset="28" id="10715" />	<!--Asn. Culottes +2-->
+		<item offset="29" id="10735" />	<!--Asn. Poulaines +2-->
+		<item offset="30" id="10656" />	<!--Vlr. Coronet +2-->
+		<item offset="31" id="10676" />	<!--Vlr. Surcoat +2-->
+		<item offset="32" id="10696" />	<!--Vlr. Gauntlets +2-->
+		<item offset="33" id="10716" />	<!--Vlr. Breeches +2-->
+		<item offset="34" id="10736" />	<!--Vlr. Leggings +2-->
+		<item offset="35" id="10657" />	<!--Abs. Burgeonet +2-->
+		<item offset="36" id="10677" />	<!--Abs. Cuirass +2-->
+		<item offset="37" id="10697" />	<!--Abs. Gauntlets +2-->
+		<item offset="38" id="10717" />	<!--Abs. Flanchard +2-->
+		<item offset="39" id="10737" />	<!--Abs. Sollerets +2-->
+		<item offset="40" id="10658" />	<!--Mst. Helm +2-->
+		<item offset="41" id="10678" />	<!--Mst. Jackcoat +2-->
+		<item offset="42" id="10698" />	<!--Mst. Gloves +2-->
+		<item offset="43" id="10718" />	<!--Mst. Trousers +2-->
+		<item offset="44" id="10738" />	<!--Mst. Gaiters +2-->
+		<item offset="45" id="10659" />	<!--Brd. Roundlet +2-->
+		<item offset="46" id="10679" />	<!--Brd. Jstcorps +2-->
+		<item offset="47" id="10699" />	<!--Brd. Cuffs +2-->
+		<item offset="48" id="10719" />	<!--Brd. Cannions +2-->
+		<item offset="49" id="10739" />	<!--Brd. Slippers +2-->
+		<item offset="50" id="10660" />	<!--Sct. Beret +2-->
+		<item offset="51" id="10680" />	<!--Sct. Jerkin +2-->
+		<item offset="52" id="10700" />	<!--Sct. Bracers +2-->
+		<item offset="53" id="10720" />	<!--Sct. Braccae +2-->
+		<item offset="54" id="10740" />	<!--Sct. Socks +2-->
+		<item offset="55" id="10661" />	<!--Sao. Kabuto +2-->
+		<item offset="56" id="10681" />	<!--Sao. Domaru +2-->
+		<item offset="57" id="10701" />	<!--Sao. Kote +2-->
+		<item offset="58" id="10721" />	<!--Sao. Haidate +2-->
+		<item offset="59" id="10741" />	<!--Sao. Sune-Ate +2-->
+		<item offset="60" id="10662" />	<!--Kog. Hatsuburi +2-->
+		<item offset="61" id="10682" />	<!--Kog. Chainmail +2-->
+		<item offset="62" id="10702" />	<!--Kog. Tekko +2-->
+		<item offset="63" id="10722" />	<!--Kog. Hakama +2-->
+		<item offset="64" id="10742" />	<!--Kog. Kyahan +2-->
+		<item offset="65" id="10663" />	<!--Wym. Armet +2-->
+		<item offset="66" id="10683" />	<!--Wym. Mail +2-->
+		<item offset="67" id="10703" />	<!--Wym. Fng. Gnt. +2-->
+		<item offset="68" id="10723" />	<!--Wym. Brais +2-->
+		<item offset="69" id="10743" />	<!--Wym. Greaves +2-->
+		<item offset="70" id="10664" />	<!--Smn. Horn +2-->
+		<item offset="71" id="10684" />	<!--Smn. Doublet +2-->
+		<item offset="72" id="10704" />	<!--Smn. Bracers +2-->
+		<item offset="73" id="10724" />	<!--Smn. Spats +2-->
+		<item offset="74" id="10744" />	<!--Smn. Pigaches +2-->
+		<item offset="75" id="10665" />	<!--Mirage Keffiyeh +2-->
+		<item offset="76" id="10685" />	<!--Mirage Jubbah +2-->
+		<item offset="77" id="10705" />	<!--Mrg. Bazubands +2-->
+		<item offset="78" id="10725" />	<!--Mirage Shalwar +2-->
+		<item offset="79" id="10745" />	<!--Mirage Charuqs +2-->
+		<item offset="80" id="10666" />	<!--Comm. Tricorne +2-->
+		<item offset="81" id="10686" />	<!--Comm. Frac +2-->
+		<item offset="82" id="10706" />	<!--Comm. Gants +2-->
+		<item offset="83" id="10726" />	<!--Comm. Trews +2-->
+		<item offset="84" id="10746" />	<!--Comm. Bottes +2-->
+		<item offset="85" id="10667" />	<!--Pantin Taj +2-->
+		<item offset="86" id="10687" />	<!--Pantin Tobe +2-->
+		<item offset="87" id="10707" />	<!--Pantin Dastanas +2-->
+		<item offset="88" id="10727" />	<!--Ptn. Churidars +2-->
+		<item offset="89" id="10747" />	<!--Ptn. Babouches +2-->
+		<item offset="90" id="10668" />	<!--Etoile Tiara +2-->
+		<item offset="91" id="10688" />	<!--Etoile Casaque +2-->
+		<item offset="92" id="10708" />	<!--Etoile Bangles +2-->
+		<item offset="93" id="10728" />	<!--Etoile Tights +2-->
+		<item offset="94" id="10748" />	<!--Etoile Toe Shoes +2-->
+		<item offset="95" id="10669" />	<!--Argute M.board +2-->
+		<item offset="96" id="10689" />	<!--Argute Gown +2-->
+		<item offset="97" id="10709" />	<!--Argute Bracers +2-->
+		<item offset="98" id="10729" />	<!--Argute Pants +2-->
+		<item offset="99" id="10749" />	<!--Argute Loafers +2-->
+	</slip>
+	<slip id="29325">		<!--Storage Slip 14-->
+		<item offset="0" id="10901" />	<!--Phorcys Salade-->
+		<item offset="1" id="10474" />	<!--Phorcys Korazin-->
+		<item offset="2" id="10523" />	<!--Phorcys Mitts-->
+		<item offset="3" id="10554" />	<!--Phorcys Dirs-->
+		<item offset="4" id="10620" />	<!--Phorcys Schuhs-->
+		<item offset="5" id="10906" />	<!--Thaumas Hat-->
+		<item offset="6" id="10479" />	<!--Thaumas Coat-->
+		<item offset="7" id="10528" />	<!--Thaumas Gloves-->
+		<item offset="8" id="10559" />	<!--Thaumas Kecks-->
+		<item offset="9" id="10625" />	<!--Thaumas Nails-->
+		<item offset="10" id="10911" />	<!--Nares Cap-->
+		<item offset="11" id="10484" />	<!--Nares Saio-->
+		<item offset="12" id="10533" />	<!--Nares Cuffs-->
+		<item offset="13" id="10564" />	<!--Nares Trews-->
+		<item offset="14" id="10630" />	<!--Nares Clogs-->
+		<item offset="15" id="19799" />	<!--Herja's Fork-->
+		<item offset="16" id="18916" />	<!--Heimdall's Doom-->
+		<item offset="17" id="10442" />	<!--Laeradr Helm-->
+		<item offset="18" id="10280" />	<!--Laeradr Breastplate-->
+		<item offset="19" id="16084" />	<!--Ares' Mask-->
+		<item offset="20" id="27788" />	<!--Ares' Cuirass +1-->
+		<item offset="21" id="27928" />	<!--Ares' Gauntlets +1-->
+		<item offset="22" id="28071" />	<!--Ares' Flanchard +1-->
+		<item offset="23" id="28208" />	<!--Ares' Sollerets +1-->
+		<item offset="24" id="27649" />	<!--Skadi's Visor +1-->
+		<item offset="25" id="27789" />	<!--Skadi's Cuirie +1-->
+		<item offset="26" id="27929" />	<!--Skd. Bazubands +1-->
+		<item offset="27" id="28072" />	<!--Skd. Chausses +1-->
+		<item offset="28" id="28209" />	<!--Skd. Jambeaux +1-->
+		<item offset="29" id="27650" />	<!--Usk. Somen +1-->
+		<item offset="30" id="27790" />	<!--Usk. Haramaki +1-->
+		<item offset="31" id="27930" />	<!--Usk. Gote +1-->
+		<item offset="32" id="28073" />	<!--Usk. Hizayoroi +1-->
+		<item offset="33" id="28210" />	<!--Usk. Sune-Ate +1-->
+		<item offset="34" id="27651" />	<!--Marduk's Tiara +1-->
+		<item offset="35" id="27791" />	<!--Marduk's Jubbah +1-->
+		<item offset="36" id="27931" />	<!--Mdk. Dastanas +1-->
+		<item offset="37" id="28074" />	<!--Mdk. Shalwar +1-->
+		<item offset="38" id="28211" />	<!--Mdk. Crackows +1-->
+		<item offset="39" id="27652" />	<!--Mor. Coronal +1-->
+		<item offset="40" id="27792" />	<!--Morrigan's Robe +1-->
+		<item offset="41" id="27932" />	<!--Morrigan's Cuffs +1-->
+		<item offset="42" id="28075" />	<!--Morrigan's Slops +1-->
+		<item offset="43" id="28212" />	<!--Morrigan's Pgch. +1-->
+		<item offset="44" id="27653" />	<!--Ker's Mask-->
+		<item offset="45" id="27793" />	<!--Ker's Cuirass-->
+		<item offset="46" id="27933" />	<!--Ker's Gauntlets-->
+		<item offset="47" id="28076" />	<!--Ker's Flanchard-->
+		<item offset="48" id="28213" />	<!--Ker's Sollerets-->
+		<item offset="49" id="27654" />	<!--Sigyn's Visor-->
+		<item offset="50" id="27794" />	<!--Sigyn's Cuirie-->
+		<item offset="51" id="27934" />	<!--Sigyn's Bazubands-->
+		<item offset="52" id="28077" />	<!--Sigyn's Chausses-->
+		<item offset="53" id="28214" />	<!--Sigyn's Jambeaux-->
+		<item offset="54" id="27655" />	<!--Omodaka Somen-->
+		<item offset="55" id="27795" />	<!--Omodaka Haramaki-->
+		<item offset="56" id="27935" />	<!--Omodaka Gote-->
+		<item offset="57" id="28078" />	<!--Omo. Hizayoroi-->
+		<item offset="58" id="28215" />	<!--Omo. Sune-Ate-->
+		<item offset="59" id="27656" />	<!--Nabu's Tiara-->
+		<item offset="60" id="27796" />	<!--Nabu's Jubbah-->
+		<item offset="61" id="27936" />	<!--Nabu's Dastanas-->
+		<item offset="62" id="28079" />	<!--Nabu's Shalwar-->
+		<item offset="63" id="28216" />	<!--Nabu's Crackows-->
+		<item offset="64" id="27657" />	<!--Fea's Coronal-->
+		<item offset="65" id="27797" />	<!--Fea's Robe-->
+		<item offset="66" id="27937" />	<!--Fea's Cuffs-->
+		<item offset="67" id="28080" />	<!--Fea's Slops-->
+		<item offset="68" id="28217" />	<!--Fea's Pigaches-->
+		<item offset="69" id="27658" />	<!--Ate's Mask-->
+		<item offset="70" id="27798" />	<!--Ate's Cuirass-->
+		<item offset="71" id="27938" />	<!--Ate's Gauntlets-->
+		<item offset="72" id="28081" />	<!--Ate's Flanchard-->
+		<item offset="73" id="28218" />	<!--Ate's Sollerets-->
+		<item offset="74" id="27659" />	<!--Idi's Mask-->
+		<item offset="75" id="27799" />	<!--Idi's Jerkin-->
+		<item offset="76" id="27939" />	<!--Idi's Gloves-->
+		<item offset="77" id="28082" />	<!--Idi's Trousers-->
+		<item offset="78" id="28219" />	<!--Idi's Ledelsens-->
+		<item offset="79" id="27660" />	<!--Genta Kabuto-->
+		<item offset="80" id="27800" />	<!--Genta Hara-Ate-->
+		<item offset="81" id="27940" />	<!--Genta Gote-->
+		<item offset="82" id="28083" />	<!--Genta-no-Hakama-->
+		<item offset="83" id="28220" />	<!--Genta Sune-Ate-->
+		<item offset="84" id="27661" />	<!--Namru's Tiara-->
+		<item offset="85" id="27801" />	<!--Namru's Jubbah-->
+		<item offset="86" id="27941" />	<!--Namru's Dastanas-->
+		<item offset="87" id="28084" />	<!--Namru's Shalwar-->
+		<item offset="88" id="28221" />	<!--Namru's Crackows-->
+		<item offset="89" id="27662" />	<!--Neit's Crown-->
+		<item offset="90" id="27802" />	<!--Neit's Coat-->
+		<item offset="91" id="27942" />	<!--Neit's Cuffs-->
+		<item offset="92" id="28085" />	<!--Neit's Slops-->
+		<item offset="93" id="28222" />	<!--Neit's Pigaches-->
+		<item offset="94" id="21510" />	<!--Voluspa Knuckles-->
+		<item offset="95" id="21566" />	<!--Voluspa Knife-->
+		<item offset="96" id="21622" />	<!--Voluspa Sword-->
+		<item offset="97" id="21665" />	<!--Voluspa Blade-->
+		<item offset="98" id="21712" />	<!--Voluspa Axe-->
+		<item offset="99" id="21769" />	<!--Voluspa Chopper-->
+		<item offset="100" id="21822" />	<!--Voluspa Scythe-->
+		<item offset="101" id="21864" />	<!--Voluspa Lance-->
+		<item offset="102" id="21912" />	<!--Voluspa Katana-->
+		<item offset="103" id="21976" />	<!--Voluspa Tachi-->
+		<item offset="104" id="22006" />	<!--Voluspa Hammer-->
+		<item offset="105" id="22088" />	<!--Voluspa Pole-->
+		<item offset="106" id="22133" />	<!--Voluspa Bow-->
+		<item offset="107" id="22144" />	<!--Voluspa Gun-->
+		<item offset="108" id="22219" />	<!--Voluspa Grip-->
+		<item offset="109" id="26413" />	<!--Voluspa Shield-->
+		<item offset="110" id="23738" />	<!--Hervor Galea-->
+		<item offset="111" id="23741" />	<!--Hervor Haubert-->
+		<item offset="112" id="23744" />	<!--Hervor Mouffles-->
+		<item offset="113" id="23747" />	<!--Hervor Brayettes-->
+		<item offset="114" id="23750" />	<!--Hervor Sollerets-->
+		<item offset="115" id="23739" />	<!--Heidrek Mask-->
+		<item offset="116" id="23742" />	<!--Heidrek Harness-->
+		<item offset="117" id="23745" />	<!--Heidrek Gloves-->
+		<item offset="118" id="23748" />	<!--Heidrek Brais-->
+		<item offset="119" id="23751" />	<!--Heidrek Boots-->
+		<item offset="120" id="23740" />	<!--Angantyr Beret-->
+		<item offset="121" id="23743" />	<!--Angantyr Robe-->
+		<item offset="122" id="23746" />	<!--Angantyr Mittens-->
+		<item offset="123" id="23749" />	<!--Angantyr Tights-->
+		<item offset="124" id="23752" />	<!--Angantyr Boots-->
+	</slip>
+	<slip id="29326">		<!--Storage Slip 15-->
+		<item offset="0" id="27663" />	<!--Pummeler's Mask-->
+		<item offset="1" id="27807" />	<!--Pummeler's Lorica-->
+		<item offset="2" id="27943" />	<!--Pumm. Mufflers-->
+		<item offset="3" id="28090" />	<!--Pumm. Cuisses-->
+		<item offset="4" id="28223" />	<!--Pumm. Calligae-->
+		<item offset="5" id="27664" />	<!--Anchorite's Crown-->
+		<item offset="6" id="27808" />	<!--Anchorite's Cyclas-->
+		<item offset="7" id="27944" />	<!--Anchorite's Gloves-->
+		<item offset="8" id="28091" />	<!--Anchorite's Hose-->
+		<item offset="9" id="28224" />	<!--Anch. Gaiters-->
+		<item offset="10" id="27665" />	<!--Theophany Cap-->
+		<item offset="11" id="27809" />	<!--Theo. Bliaut-->
+		<item offset="12" id="27945" />	<!--Theophany Mitts-->
+		<item offset="13" id="28092" />	<!--Theo. Pantaloons-->
+		<item offset="14" id="28225" />	<!--Theo. Duckbills-->
+		<item offset="15" id="27666" />	<!--Spae. Petasos-->
+		<item offset="16" id="27810" />	<!--Spaekona's Coat-->
+		<item offset="17" id="27946" />	<!--Spaekona's Gloves-->
+		<item offset="18" id="28093" />	<!--Spaekona's Tonban-->
+		<item offset="19" id="28226" />	<!--Spaekona's Sabots-->
+		<item offset="20" id="27667" />	<!--Atrophy Chapeau-->
+		<item offset="21" id="27811" />	<!--Atrophy Tabard-->
+		<item offset="22" id="27947" />	<!--Atrophy Gloves-->
+		<item offset="23" id="28094" />	<!--Atrophy Tights-->
+		<item offset="24" id="28227" />	<!--Atrophy Boots-->
+		<item offset="25" id="27668" />	<!--Pillager's Bonnet-->
+		<item offset="26" id="27812" />	<!--Pillager's Vest-->
+		<item offset="27" id="27948" />	<!--Pillager's Armlets-->
+		<item offset="28" id="28095" />	<!--Pillager's Culottes-->
+		<item offset="29" id="28228" />	<!--Pillager's Poulaines-->
+		<item offset="30" id="27669" />	<!--Rev. Coronet-->
+		<item offset="31" id="27813" />	<!--Reverence Surcoat-->
+		<item offset="32" id="27949" />	<!--Rev. Gauntlets-->
+		<item offset="33" id="28096" />	<!--Rev. Breeches-->
+		<item offset="34" id="28229" />	<!--Rev. Leggings-->
+		<item offset="35" id="27670" />	<!--Ignominy Burgeonet-->
+		<item offset="36" id="27814" />	<!--Ignominy Cuirass-->
+		<item offset="37" id="27950" />	<!--Igno. Gauntlets-->
+		<item offset="38" id="28097" />	<!--Ignominy Flanchard-->
+		<item offset="39" id="28230" />	<!--Igno. Sollerets-->
+		<item offset="40" id="27671" />	<!--Totemic Helm-->
+		<item offset="41" id="27815" />	<!--Totemic Jackcoat-->
+		<item offset="42" id="27951" />	<!--Totemic Gloves-->
+		<item offset="43" id="28098" />	<!--Totemic Trousers-->
+		<item offset="44" id="28231" />	<!--Totemic Gaiters-->
+		<item offset="45" id="27672" />	<!--Brioso Roundlet-->
+		<item offset="46" id="27816" />	<!--Brioso Just.-->
+		<item offset="47" id="27952" />	<!--Brioso Cuffs-->
+		<item offset="48" id="28099" />	<!--Brioso Cannions-->
+		<item offset="49" id="28232" />	<!--Brioso Slippers-->
+		<item offset="50" id="27673" />	<!--Orion Beret-->
+		<item offset="51" id="27817" />	<!--Orion Jerkin-->
+		<item offset="52" id="27953" />	<!--Orion Bracers-->
+		<item offset="53" id="28100" />	<!--Orion Braccae-->
+		<item offset="54" id="28233" />	<!--Orion Socks-->
+		<item offset="55" id="27674" />	<!--Wakido Kabuto-->
+		<item offset="56" id="27818" />	<!--Wakido Domaru-->
+		<item offset="57" id="27954" />	<!--Wakido Kote-->
+		<item offset="58" id="28101" />	<!--Wakido Haidate-->
+		<item offset="59" id="28234" />	<!--Wakido Sune-Ate-->
+		<item offset="60" id="27675" />	<!--Hachiya Hatsuburi-->
+		<item offset="61" id="27819" />	<!--Hachi. Chainmail-->
+		<item offset="62" id="27955" />	<!--Hachiya Tekko-->
+		<item offset="63" id="28102" />	<!--Hachiya Hakama-->
+		<item offset="64" id="28235" />	<!--Hachiya Kyahan-->
+		<item offset="65" id="27676" />	<!--Vishap Armet-->
+		<item offset="66" id="27820" />	<!--Vishap Mail-->
+		<item offset="67" id="27956" />	<!--Vish. Fin. Gaunt-->
+		<item offset="68" id="28103" />	<!--Vishap Brais-->
+		<item offset="69" id="28236" />	<!--Vishap Greaves-->
+		<item offset="70" id="27677" />	<!--Convoker's Horn-->
+		<item offset="71" id="27821" />	<!--Convo. Doublet-->
+		<item offset="72" id="27957" />	<!--Con. Bracers-->
+		<item offset="73" id="28104" />	<!--Convoker's Spats-->
+		<item offset="74" id="28237" />	<!--Con. Pigaches-->
+		<item offset="75" id="27678" />	<!--Assim. Keffiyeh-->
+		<item offset="76" id="27822" />	<!--Assim. Jubbah-->
+		<item offset="77" id="27958" />	<!--Assim. Bazu.-->
+		<item offset="78" id="28105" />	<!--Assim. Shalwar-->
+		<item offset="79" id="28238" />	<!--Assim. Charuqs-->
+		<item offset="80" id="27679" />	<!--Laksa. Tricorne-->
+		<item offset="81" id="27823" />	<!--Laksa. Frac-->
+		<item offset="82" id="27959" />	<!--Laksa. Gants-->
+		<item offset="83" id="28106" />	<!--Laksa. Trews-->
+		<item offset="84" id="28239" />	<!--Laksa. Bottes-->
+		<item offset="85" id="27680" />	<!--Foire Taj-->
+		<item offset="86" id="27824" />	<!--Foire Tobe-->
+		<item offset="87" id="27960" />	<!--Foire Dastanas-->
+		<item offset="88" id="28107" />	<!--Foire Churidars-->
+		<item offset="89" id="28240" />	<!--Foire Babouches-->
+		<item offset="90" id="27681" />	<!--Maxixi Tiara-->
+		<item offset="91" id="27825" />	<!--Maxixi Casaque-->
+		<item offset="92" id="27961" />	<!--Maxixi Bangles-->
+		<item offset="93" id="28108" />	<!--Maxixi Tights-->
+		<item offset="94" id="28241" />	<!--Maxixi Toe Shoes-->
+		<item offset="95" id="27682" />	<!--Maxixi Tiara-->
+		<item offset="96" id="27826" />	<!--Maxixi Casaque-->
+		<item offset="97" id="27962" />	<!--Maxixi Bangles-->
+		<item offset="98" id="28109" />	<!--Maxixi Tights-->
+		<item offset="99" id="28242" />	<!--Maxixi Toe Shoes-->
+		<item offset="100" id="27683" />	<!--Acad. Mortarboard-->
+		<item offset="101" id="27827" />	<!--Academic's Gown-->
+		<item offset="102" id="27963" />	<!--Acad. Bracers-->
+		<item offset="103" id="28110" />	<!--Academic's Pants-->
+		<item offset="104" id="28243" />	<!--Acad. Loafers-->
+	</slip>
+	<slip id="29327">		<!--Storage Slip 16-->
+		<item offset="0" id="27684" />	<!--Pumm. Mask +1-->
+		<item offset="1" id="27828" />	<!--Pumm. Lorica +1-->
+		<item offset="2" id="27964" />	<!--Pumm. Mufflers +1-->
+		<item offset="3" id="28111" />	<!--Pumm. Cuisses +1-->
+		<item offset="4" id="28244" />	<!--Pumm. Calligae +1-->
+		<item offset="5" id="27685" />	<!--Anchor. Crown +1-->
+		<item offset="6" id="27829" />	<!--Anch. Cyclas +1-->
+		<item offset="7" id="27965" />	<!--Anch. Gloves +1-->
+		<item offset="8" id="28112" />	<!--Anch. Hose +1-->
+		<item offset="9" id="28245" />	<!--Anch. Gaiters +1-->
+		<item offset="10" id="27686" />	<!--Theo. Cap +1-->
+		<item offset="11" id="27830" />	<!--Theo. Bliaut +1-->
+		<item offset="12" id="27966" />	<!--Theo. Mitts +1-->
+		<item offset="13" id="28113" />	<!--Theo. Pant. +1-->
+		<item offset="14" id="28246" />	<!--Theo. Duckbills +1-->
+		<item offset="15" id="27687" />	<!--Spae. Petasos +1-->
+		<item offset="16" id="27831" />	<!--Spae. Coat +1-->
+		<item offset="17" id="27967" />	<!--Spae. Gloves +1-->
+		<item offset="18" id="28114" />	<!--Spae. Tonban +1-->
+		<item offset="19" id="28247" />	<!--Spae. Sabots +1-->
+		<item offset="20" id="27688" />	<!--Atro. Chapeau +1-->
+		<item offset="21" id="27832" />	<!--Atrophy Tabard +1-->
+		<item offset="22" id="27968" />	<!--Atrophy Gloves +1-->
+		<item offset="23" id="28115" />	<!--Atrophy Tights +1-->
+		<item offset="24" id="28248" />	<!--Atrophy Boots +1-->
+		<item offset="25" id="27689" />	<!--Pill. Bonnet +1-->
+		<item offset="26" id="27833" />	<!--Pillager's Vest +1-->
+		<item offset="27" id="27969" />	<!--Pill. Armlets +1-->
+		<item offset="28" id="28116" />	<!--Pill. Culottes +1-->
+		<item offset="29" id="28249" />	<!--Pill. Poulaines +1-->
+		<item offset="30" id="27690" />	<!--Rev. Coronet +1-->
+		<item offset="31" id="27834" />	<!--Rev. Surcoat +1-->
+		<item offset="32" id="27970" />	<!--Rev. Gauntlets +1-->
+		<item offset="33" id="28117" />	<!--Rev. Breeches +1-->
+		<item offset="34" id="28250" />	<!--Rev. Leggings +1-->
+		<item offset="35" id="27691" />	<!--Igno. Burgeonet +1-->
+		<item offset="36" id="27835" />	<!--Igno. Cuirass +1-->
+		<item offset="37" id="27971" />	<!--Igno. Gauntlets +1-->
+		<item offset="38" id="28118" />	<!--Igno. Flan. +1-->
+		<item offset="39" id="28251" />	<!--Igno. Sollerets +1-->
+		<item offset="40" id="27692" />	<!--Totemic Helm +1-->
+		<item offset="41" id="27836" />	<!--Tot. Jackcoat +1-->
+		<item offset="42" id="27972" />	<!--Tot. Gloves +1-->
+		<item offset="43" id="28119" />	<!--Tot. Trousers +1-->
+		<item offset="44" id="28252" />	<!--Tot. Gaiters +1-->
+		<item offset="45" id="27693" />	<!--Brioso Roundlet +1-->
+		<item offset="46" id="27837" />	<!--Brioso Just. +1-->
+		<item offset="47" id="27973" />	<!--Brioso Cuffs +1-->
+		<item offset="48" id="28120" />	<!--Brioso Cann. +1-->
+		<item offset="49" id="28253" />	<!--Brioso Slippers +1-->
+		<item offset="50" id="27694" />	<!--Orion Beret +1-->
+		<item offset="51" id="27838" />	<!--Orion Jerkin +1-->
+		<item offset="52" id="27974" />	<!--Orion Bracers +1-->
+		<item offset="53" id="28121" />	<!--Orion Braccae +1-->
+		<item offset="54" id="28254" />	<!--Orion Socks +1-->
+		<item offset="55" id="27695" />	<!--Wakido Kabuto +1-->
+		<item offset="56" id="27839" />	<!--Wakido Domaru +1-->
+		<item offset="57" id="27975" />	<!--Wakido Kote +1-->
+		<item offset="58" id="28122" />	<!--Wakido Haidate +1-->
+		<item offset="59" id="28255" />	<!--Waki. Sune-Ate +1-->
+		<item offset="60" id="27696" />	<!--Hachi. Hatsu. +1-->
+		<item offset="61" id="27840" />	<!--Hachi. Chain. +1-->
+		<item offset="62" id="27976" />	<!--Hachiya Tekko +1-->
+		<item offset="63" id="28123" />	<!--Hachi. Hakama +1-->
+		<item offset="64" id="28256" />	<!--Hachi. Kyahan +1-->
+		<item offset="65" id="27697" />	<!--Vishap Armet +1-->
+		<item offset="66" id="27841" />	<!--Vishap Mail +1-->
+		<item offset="67" id="27977" />	<!--Vishap F. G. +1-->
+		<item offset="68" id="28124" />	<!--Vishap Brais +1-->
+		<item offset="69" id="28257" />	<!--Vishap Greaves +1-->
+		<item offset="70" id="27698" />	<!--Con. Horn +1-->
+		<item offset="71" id="27842" />	<!--Con. Doublet +1-->
+		<item offset="72" id="27978" />	<!--Con. Bracers +1-->
+		<item offset="73" id="28125" />	<!--Con. Spats +1-->
+		<item offset="74" id="28258" />	<!--Con. Pigaches +1-->
+		<item offset="75" id="27699" />	<!--Assim. Keffiyeh +1-->
+		<item offset="76" id="27843" />	<!--Assim. Jubbah +1-->
+		<item offset="77" id="27979" />	<!--Assim. Bazu. +1-->
+		<item offset="78" id="28126" />	<!--Assim. Shalwar +1-->
+		<item offset="79" id="28259" />	<!--Assim. Charuqs +1-->
+		<item offset="80" id="27700" />	<!--Laksa. Tricorne +1-->
+		<item offset="81" id="27844" />	<!--Laksa. Frac +1-->
+		<item offset="82" id="27980" />	<!--Laksa. Gants +1-->
+		<item offset="83" id="28127" />	<!--Laksa. Trews +1-->
+		<item offset="84" id="28260" />	<!--Laksa. Bottes +1-->
+		<item offset="85" id="27701" />	<!--Foire Taj +1-->
+		<item offset="86" id="27845" />	<!--Foire Tobe +1-->
+		<item offset="87" id="27981" />	<!--Foire Dastanas +1-->
+		<item offset="88" id="28128" />	<!--Foire Churidars +1-->
+		<item offset="89" id="28261" />	<!--Foire Bab. +1-->
+		<item offset="90" id="27702" />	<!--Maxixi Tiara +1-->
+		<item offset="91" id="27846" />	<!--Maxixi Casaque +1-->
+		<item offset="92" id="27982" />	<!--Maxixi Bangles +1-->
+		<item offset="93" id="28129" />	<!--Maxixi Tights +1-->
+		<item offset="94" id="28262" />	<!--Maxixi Toe Shoes +1-->
+		<item offset="95" id="27703" />	<!--Maxixi Tiara +1-->
+		<item offset="96" id="27847" />	<!--Maxixi Casaque +1-->
+		<item offset="97" id="27983" />	<!--Maxixi Bangles +1-->
+		<item offset="98" id="28130" />	<!--Maxixi Tights +1-->
+		<item offset="99" id="28263" />	<!--Maxixi Toe Shoes +1-->
+		<item offset="100" id="27704" />	<!--Acad. Mortar. +1-->
+		<item offset="101" id="27848" />	<!--Acad. Gown +1-->
+		<item offset="102" id="27984" />	<!--Acad. Bracers +1-->
+		<item offset="103" id="28131" />	<!--Acad. Pants +1-->
+		<item offset="104" id="28264" />	<!--Acad. Loafers +1-->
+		<item offset="105" id="27705" />	<!--Geo. Galero +1-->
+		<item offset="106" id="27849" />	<!--Geo. Tunic +1-->
+		<item offset="107" id="27985" />	<!--Geo. Mitaines +1-->
+		<item offset="108" id="28132" />	<!--Geo. Pants +1-->
+		<item offset="109" id="28265" />	<!--Geo. Sandals +1-->
+		<item offset="110" id="27706" />	<!--Rune. Bandeau +1-->
+		<item offset="111" id="27850" />	<!--Runeist Coat +1-->
+		<item offset="112" id="27986" />	<!--Runeist Mitons +1-->
+		<item offset="113" id="28133" />	<!--Rune. Trousers +1-->
+		<item offset="114" id="28266" />	<!--Runeist Bottes +1-->
+	</slip>
+	<slip id="29328">		<!--Storage Slip 17-->
+		<item offset="0" id="26624" />	<!--Agoge Mask-->
+		<item offset="1" id="26800" />	<!--Agoge Lorica-->
+		<item offset="2" id="26976" />	<!--Agoge Mufflers-->
+		<item offset="3" id="27152" />	<!--Agoge Cuisses-->
+		<item offset="4" id="27328" />	<!--Agoge Calligae-->
+		<item offset="5" id="26626" />	<!--Hes. Crown-->
+		<item offset="6" id="26802" />	<!--Hes. Cyclas-->
+		<item offset="7" id="26978" />	<!--Hes. Gloves-->
+		<item offset="8" id="27154" />	<!--Hes. Hose-->
+		<item offset="9" id="27330" />	<!--Hes. Gaiters-->
+		<item offset="10" id="26628" />	<!--Piety Cap-->
+		<item offset="11" id="26804" />	<!--Piety Bliaut-->
+		<item offset="12" id="26980" />	<!--Piety Mitts-->
+		<item offset="13" id="27156" />	<!--Piety Pantaloons-->
+		<item offset="14" id="27332" />	<!--Piety Duckbills-->
+		<item offset="15" id="26630" />	<!--Arch. Petasos-->
+		<item offset="16" id="26806" />	<!--Arch. Coat-->
+		<item offset="17" id="26982" />	<!--Arch. Gloves-->
+		<item offset="18" id="27158" />	<!--Arch. Tonban-->
+		<item offset="19" id="27334" />	<!--Arch. Sabots-->
+		<item offset="20" id="26632" />	<!--Vitiation Chapeau-->
+		<item offset="21" id="26808" />	<!--Vitiation Tabard-->
+		<item offset="22" id="26984" />	<!--Vitiation Gloves-->
+		<item offset="23" id="27160" />	<!--Vitiation Tights-->
+		<item offset="24" id="27336" />	<!--Vitiation Boots-->
+		<item offset="25" id="26634" />	<!--Plun. Bonnet-->
+		<item offset="26" id="26810" />	<!--Plunderer's Vest-->
+		<item offset="27" id="26986" />	<!--Plun. Armlets-->
+		<item offset="28" id="27162" />	<!--Plun. Culottes-->
+		<item offset="29" id="27338" />	<!--Plun. Poulaines-->
+		<item offset="30" id="26636" />	<!--Cab. Coronet-->
+		<item offset="31" id="26812" />	<!--Cab. Surcoat-->
+		<item offset="32" id="26988" />	<!--Cab. Gauntlets-->
+		<item offset="33" id="27164" />	<!--Cab. Breeches-->
+		<item offset="34" id="27340" />	<!--Cab. Leggings-->
+		<item offset="35" id="26638" />	<!--Fallen's Burgeonet-->
+		<item offset="36" id="26814" />	<!--Fallen's Cuirass-->
+		<item offset="37" id="26990" />	<!--Fall. Fin. Gaunt.-->
+		<item offset="38" id="27166" />	<!--Fallen's Flanchard-->
+		<item offset="39" id="27342" />	<!--Fallen's Sollerets-->
+		<item offset="40" id="26640" />	<!--Ankusa Helm-->
+		<item offset="41" id="26816" />	<!--Ankusa Jackcoat-->
+		<item offset="42" id="26992" />	<!--Ankusa Gloves-->
+		<item offset="43" id="27168" />	<!--Ankusa Trousers-->
+		<item offset="44" id="27344" />	<!--Ankusa Gaiters-->
+		<item offset="45" id="26642" />	<!--Bihu Roundlet-->
+		<item offset="46" id="26818" />	<!--Bihu Justaucorps-->
+		<item offset="47" id="26994" />	<!--Bihu Cuffs-->
+		<item offset="48" id="27170" />	<!--Bihu Cannions-->
+		<item offset="49" id="27346" />	<!--Bihu Slippers-->
+		<item offset="50" id="26644" />	<!--Arcadian Beret-->
+		<item offset="51" id="26820" />	<!--Arcadian Jerkin-->
+		<item offset="52" id="26996" />	<!--Arcadian Bracers-->
+		<item offset="53" id="27172" />	<!--Arcadian Braccae-->
+		<item offset="54" id="27348" />	<!--Arcadian Socks-->
+		<item offset="55" id="26646" />	<!--Sakonji Kabuto-->
+		<item offset="56" id="26822" />	<!--Sakonji Domaru-->
+		<item offset="57" id="26998" />	<!--Sakonji Kote-->
+		<item offset="58" id="27174" />	<!--Sakonji Haidate-->
+		<item offset="59" id="27350" />	<!--Sakonji Sune-Ate-->
+		<item offset="60" id="26648" />	<!--Mochi. Hatsuburi-->
+		<item offset="61" id="26824" />	<!--Mochi. Chainmail-->
+		<item offset="62" id="27000" />	<!--Mochizuki Tekko-->
+		<item offset="63" id="27176" />	<!--Mochizuki Hakama-->
+		<item offset="64" id="27352" />	<!--Mochizuki Kyahan-->
+		<item offset="65" id="26650" />	<!--Ptero. Armet-->
+		<item offset="66" id="26826" />	<!--Pteroslaver Mail-->
+		<item offset="67" id="27002" />	<!--Ptero. Fin. Gaunt.-->
+		<item offset="68" id="27178" />	<!--Pteroslaver Brais-->
+		<item offset="69" id="27354" />	<!--Ptero. Greaves-->
+		<item offset="70" id="26652" />	<!--Glyphic Horn-->
+		<item offset="71" id="26828" />	<!--Glyphic Doublet-->
+		<item offset="72" id="27004" />	<!--Glyphic Bracers-->
+		<item offset="73" id="27180" />	<!--Glyphic Spats-->
+		<item offset="74" id="27356" />	<!--Glyphic Pigaches-->
+		<item offset="75" id="26654" />	<!--Luhlaza Keffiyeh-->
+		<item offset="76" id="26830" />	<!--Luhlaza Jubbah-->
+		<item offset="77" id="27006" />	<!--Luhlaza Bazubands-->
+		<item offset="78" id="27182" />	<!--Luhlaza Shalwar-->
+		<item offset="79" id="27358" />	<!--Luhlaza Charuqs-->
+		<item offset="80" id="26656" />	<!--Lanun Tricorne-->
+		<item offset="81" id="26832" />	<!--Lanun Frac-->
+		<item offset="82" id="27008" />	<!--Lanun Gants-->
+		<item offset="83" id="27184" />	<!--Lanun Trews-->
+		<item offset="84" id="27360" />	<!--Lanun Bottes-->
+		<item offset="85" id="26658" />	<!--Pitre Taj-->
+		<item offset="86" id="26834" />	<!--Pitre Tobe-->
+		<item offset="87" id="27010" />	<!--Pitre Dastanas-->
+		<item offset="88" id="27186" />	<!--Pitre Churidars-->
+		<item offset="89" id="27362" />	<!--Pitre Babouches-->
+		<item offset="90" id="26660" />	<!--Horos Tiara-->
+		<item offset="91" id="26836" />	<!--Horos Casaque-->
+		<item offset="92" id="27012" />	<!--Horos Bangles-->
+		<item offset="93" id="27188" />	<!--Horos Tights-->
+		<item offset="94" id="27364" />	<!--Horos Toe Shoes-->
+		<item offset="95" id="26662" />	<!--Peda. M.Board-->
+		<item offset="96" id="26838" />	<!--Pedagogy Gown-->
+		<item offset="97" id="27014" />	<!--Peda. Bracers-->
+		<item offset="98" id="27190" />	<!--Pedagogy Pants-->
+		<item offset="99" id="27366" />	<!--Peda. Loafers-->
+		<item offset="100" id="26664" />	<!--Bagua Galero-->
+		<item offset="101" id="26840" />	<!--Bagua Tunic-->
+		<item offset="102" id="27016" />	<!--Bagua Mitaines-->
+		<item offset="103" id="27192" />	<!--Bagua Pants-->
+		<item offset="104" id="27368" />	<!--Bagua Sandals-->
+		<item offset="105" id="26666" />	<!--Futhark Bandeau-->
+		<item offset="106" id="26842" />	<!--Futhark Coat-->
+		<item offset="107" id="27018" />	<!--Futhark Mitons-->
+		<item offset="108" id="27194" />	<!--Futhark Trousers-->
+		<item offset="109" id="27370" />	<!--Futhark Boots-->
+	</slip>
+	<slip id="29329">		<!--Storage Slip 18-->
+		<item offset="0" id="26625" />	<!--Agoge Mask +1-->
+		<item offset="1" id="26801" />	<!--Agoge Lorica +1-->
+		<item offset="2" id="26977" />	<!--Agoge Mufflers +1-->
+		<item offset="3" id="27153" />	<!--Agoge Cuisses +1-->
+		<item offset="4" id="27329" />	<!--Agoge Calligae +1-->
+		<item offset="5" id="26627" />	<!--Hes. Crown +1-->
+		<item offset="6" id="26803" />	<!--Hes. Cyclas +1-->
+		<item offset="7" id="26979" />	<!--Hes. Gloves +1-->
+		<item offset="8" id="27155" />	<!--Hes. Hose +1-->
+		<item offset="9" id="27331" />	<!--Hes. Gaiters +1-->
+		<item offset="10" id="26629" />	<!--Piety Cap +1-->
+		<item offset="11" id="26805" />	<!--Piety Bliaut +1-->
+		<item offset="12" id="26981" />	<!--Piety Mitts +1-->
+		<item offset="13" id="27157" />	<!--Piety Pantaln. +1-->
+		<item offset="14" id="27333" />	<!--Piety Duckbills +1-->
+		<item offset="15" id="26631" />	<!--Arch. Petasos +1-->
+		<item offset="16" id="26807" />	<!--Arch. Coat +1-->
+		<item offset="17" id="26983" />	<!--Arch. Gloves +1-->
+		<item offset="18" id="27159" />	<!--Arch. Tonban +1-->
+		<item offset="19" id="27335" />	<!--Arch. Sabots +1-->
+		<item offset="20" id="26633" />	<!--Viti. Chapeau +1-->
+		<item offset="21" id="26809" />	<!--Viti. Tabard +1-->
+		<item offset="22" id="26985" />	<!--Viti. Gloves +1-->
+		<item offset="23" id="27161" />	<!--Viti. Tights +1-->
+		<item offset="24" id="27337" />	<!--Vitiation Boots +1-->
+		<item offset="25" id="26635" />	<!--Plun. Bonnet +1-->
+		<item offset="26" id="26811" />	<!--Plunderer's Vest +1-->
+		<item offset="27" id="26987" />	<!--Plun. Armlets +1-->
+		<item offset="28" id="27163" />	<!--Plun. Culottes +1-->
+		<item offset="29" id="27339" />	<!--Plun. Poulaines +1-->
+		<item offset="30" id="26637" />	<!--Cab. Coronet +1-->
+		<item offset="31" id="26813" />	<!--Cab. Surcoat +1-->
+		<item offset="32" id="26989" />	<!--Cab. Gauntlets +1-->
+		<item offset="33" id="27165" />	<!--Cab. Breeches +1-->
+		<item offset="34" id="27341" />	<!--Cab. Leggings +1-->
+		<item offset="35" id="26639" />	<!--Fall. Burgeonet +1-->
+		<item offset="36" id="26815" />	<!--Fall. Cuirass +1-->
+		<item offset="37" id="26991" />	<!--Fall. Fin. Gaunt. +1-->
+		<item offset="38" id="27167" />	<!--Fall. Flanchard +1-->
+		<item offset="39" id="27343" />	<!--Fall. Sollerets +1-->
+		<item offset="40" id="26641" />	<!--Ankusa Helm +1-->
+		<item offset="41" id="26817" />	<!--An. Jackcoat +1-->
+		<item offset="42" id="26993" />	<!--Ankusa Gloves +1-->
+		<item offset="43" id="27169" />	<!--Ankusa Trousers +1-->
+		<item offset="44" id="27345" />	<!--Ankusa Gaiters +1-->
+		<item offset="45" id="26643" />	<!--Bihu Roundlet +1-->
+		<item offset="46" id="26819" />	<!--Bihu Jstcorps +1-->
+		<item offset="47" id="26995" />	<!--Bihu Cuffs +1-->
+		<item offset="48" id="27171" />	<!--Bihu Cannions +1-->
+		<item offset="49" id="27347" />	<!--Bihu Slippers +1-->
+		<item offset="50" id="26645" />	<!--Arcadian Beret +1-->
+		<item offset="51" id="26821" />	<!--Arc. Jerkin +1-->
+		<item offset="52" id="26997" />	<!--Arc. Bracers +1-->
+		<item offset="53" id="27173" />	<!--Arc. Braccae +1-->
+		<item offset="54" id="27349" />	<!--Arcadian Socks +1-->
+		<item offset="55" id="26647" />	<!--Sakonji Kabuto +1-->
+		<item offset="56" id="26823" />	<!--Sakonji Domaru +1-->
+		<item offset="57" id="26999" />	<!--Sakonji Kote +1-->
+		<item offset="58" id="27175" />	<!--Sakonji Haidate +1-->
+		<item offset="59" id="27351" />	<!--Sak. Sune-Ate +1-->
+		<item offset="60" id="26649" />	<!--Mochi. Hatsuburi +1-->
+		<item offset="61" id="26825" />	<!--Mochi. Chainmail +1-->
+		<item offset="62" id="27001" />	<!--Mochizuki Tekko +1-->
+		<item offset="63" id="27177" />	<!--Mochi. Hakama +1-->
+		<item offset="64" id="27353" />	<!--Mochi. Kyahan +1-->
+		<item offset="65" id="26651" />	<!--Ptero. Armet +1-->
+		<item offset="66" id="26827" />	<!--Ptero. Mail +1-->
+		<item offset="67" id="27003" />	<!--Ptero. Fin. G. +1-->
+		<item offset="68" id="27179" />	<!--Ptero. Brais +1-->
+		<item offset="69" id="27355" />	<!--Ptero. Greaves +1-->
+		<item offset="70" id="26653" />	<!--Glyphic Horn +1-->
+		<item offset="71" id="26829" />	<!--Glyphic Doublet +1-->
+		<item offset="72" id="27005" />	<!--Glyphic Bracers +1-->
+		<item offset="73" id="27181" />	<!--Glyphic Spats +1-->
+		<item offset="74" id="27357" />	<!--Glyph. Pigaches +1-->
+		<item offset="75" id="26655" />	<!--Luh. Keffiyeh +1-->
+		<item offset="76" id="26831" />	<!--Luhlaza Jubbah +1-->
+		<item offset="77" id="27007" />	<!--Luh. Bazubands +1-->
+		<item offset="78" id="27183" />	<!--Luhlaza Shalwar +1-->
+		<item offset="79" id="27359" />	<!--Luhlaza Charuqs +1-->
+		<item offset="80" id="26657" />	<!--Lanun Tricorne +1-->
+		<item offset="81" id="26833" />	<!--Lanun Frac +1-->
+		<item offset="82" id="27009" />	<!--Lanun Gants +1-->
+		<item offset="83" id="27185" />	<!--Lanun Trews +1-->
+		<item offset="84" id="27361" />	<!--Lanun Bottes +1-->
+		<item offset="85" id="26659" />	<!--Pitre Taj +1-->
+		<item offset="86" id="26835" />	<!--Pitre Tobe +1-->
+		<item offset="87" id="27011" />	<!--Pitre Dastanas +1-->
+		<item offset="88" id="27187" />	<!--Pitre Churidars +1-->
+		<item offset="89" id="27363" />	<!--Pitre Babouches +1-->
+		<item offset="90" id="26661" />	<!--Horos Tiara +1-->
+		<item offset="91" id="26837" />	<!--Horos Casaque +1-->
+		<item offset="92" id="27013" />	<!--Horos Bangles +1-->
+		<item offset="93" id="27189" />	<!--Horos Tights +1-->
+		<item offset="94" id="27365" />	<!--Horos Toe Shoes +1-->
+		<item offset="95" id="26663" />	<!--Peda. M.Board +1-->
+		<item offset="96" id="26839" />	<!--Peda. Gown +1-->
+		<item offset="97" id="27015" />	<!--Peda. Bracers +1-->
+		<item offset="98" id="27191" />	<!--Peda. Pants +1-->
+		<item offset="99" id="27367" />	<!--Peda. Loafers +1-->
+		<item offset="100" id="26665" />	<!--Bagua Galero +1-->
+		<item offset="101" id="26841" />	<!--Bagua Tunic +1-->
+		<item offset="102" id="27017" />	<!--Bagua Mitaines +1-->
+		<item offset="103" id="27193" />	<!--Bagua Pants +1-->
+		<item offset="104" id="27369" />	<!--Bagua Sandals +1-->
+		<item offset="105" id="26667" />	<!--Fu. Bandeau +1-->
+		<item offset="106" id="26843" />	<!--Futhark Coat +1-->
+		<item offset="107" id="27019" />	<!--Futhark Mitons +1-->
+		<item offset="108" id="27195" />	<!--Futhark Trousers +1-->
+		<item offset="109" id="27371" />	<!--Futhark Boots +1-->
+	</slip>
+	<slip id="29330">		<!--Storage Slip 19-->
+		<item offset="0" id="27715" />	<!--Goblin Masque-->
+		<item offset="1" id="27866" />	<!--Goblin Suit-->
+		<item offset="2" id="27716" />	<!--G. Moogle Masque-->
+		<item offset="3" id="27867" />	<!--G. Moogle Suit-->
+		<item offset="4" id="278" />	<!--Cardian Statue-->
+		<item offset="5" id="281" />	<!--Atomos Statue-->
+		<item offset="6" id="284" />	<!--Goobbue Statue-->
+		<item offset="7" id="3680" />	<!--Judgment Day-->
+		<item offset="8" id="3681" />	<!--Alzadaal Table-->
+		<item offset="9" id="27859" />	<!--Kengyu Happi-->
+		<item offset="10" id="28149" />	<!--Ken. Hanmomohiki-->
+		<item offset="11" id="27860" />	<!--Shokujo Happi-->
+		<item offset="12" id="28150" />	<!--Sho. Hanmomohiki-->
+		<item offset="13" id="21107" />	<!--Kyuka Uchiwa-->
+		<item offset="14" id="21108" />	<!--Kyuka Uchiwa +1-->
+		<item offset="15" id="27625" />	<!--Morbol Shield-->
+		<item offset="16" id="27626" />	<!--Cassie's Shield-->
+		<item offset="17" id="26693" />	<!--Morbol Cap-->
+		<item offset="18" id="26694" />	<!--Cassie's Cap-->
+		<item offset="19" id="26707" />	<!--Flan Masque-->
+		<item offset="20" id="26708" />	<!--Flan Masque +1-->
+		<item offset="21" id="27631" />	<!--Cait Sith Guard-->
+		<item offset="22" id="27632" />	<!--Cait Sith Gua. +1-->
+		<item offset="23" id="26705" />	<!--Mandra. Masque-->
+		<item offset="24" id="26706" />	<!--Mandra. Masque +1-->
+		<item offset="25" id="27854" />	<!--Mandra. Suit-->
+		<item offset="26" id="27855" />	<!--Mandra. Suit +1-->
+		<item offset="27" id="26703" />	<!--Lyco. Masque-->
+		<item offset="28" id="26704" />	<!--Lyco. Masque +1-->
+		<item offset="29" id="3682" />	<!--Sproutling Board-->
+		<item offset="30" id="3683" />	<!--Forest. Board-->
+		<item offset="31" id="3684" />	<!--Princess Board-->
+		<item offset="32" id="3685" />	<!--Empress Board-->
+		<item offset="33" id="3686" />	<!--Duelist Board-->
+		<item offset="34" id="3687" />	<!--Crystal Board-->
+		<item offset="35" id="3688" />	<!--Dancer Board-->
+		<item offset="36" id="3689" />	<!--Wizardess Board-->
+		<item offset="37" id="3690" />	<!--Fighter Board-->
+		<item offset="38" id="3691" />	<!--Guardian Board-->
+		<item offset="39" id="3692" />	<!--Stoic Board-->
+		<item offset="40" id="3693" />	<!--Lamb Carving-->
+		<item offset="41" id="3694" />	<!--Pol. Lamb Carving-->
+		<item offset="42" id="3695" />	<!--Cait Sith Car.-->
+		<item offset="43" id="21097" />	<!--Leafkin Bopper-->
+		<item offset="44" id="21098" />	<!--Leafkin Bopper +1-->
+		<item offset="45" id="26717" />	<!--Cait Sith Cap-->
+		<item offset="46" id="26718" />	<!--Cait Sith Cap +1-->
+		<item offset="47" id="26728" />	<!--Frosty Cap-->
+		<item offset="48" id="26719" />	<!--Sheep Cap-->
+		<item offset="49" id="26720" />	<!--Sheep Cap +1-->
+		<item offset="50" id="26889" />	<!--Heart Apron-->
+		<item offset="51" id="26890" />	<!--Heart Apron +1-->
+		<item offset="52" id="21095" />	<!--Heartbeater-->
+		<item offset="53" id="21096" />	<!--Heartbeater +1-->
+		<item offset="54" id="26738" />	<!--Leafkin Cap-->
+		<item offset="55" id="26739" />	<!--Leafkin Cap +1-->
+		<item offset="56" id="26729" />	<!--Corolla-->
+		<item offset="57" id="26730" />	<!--Celeste Cap-->
+		<item offset="58" id="26788" />	<!--Rabbit Cap-->
+		<item offset="59" id="26946" />	<!--Pupil's Shirt-->
+		<item offset="60" id="27281" />	<!--Pupil's Trousers-->
+		<item offset="61" id="27455" />	<!--Pupil's Shoes-->
+		<item offset="62" id="26789" />	<!--Shobuhouou Kabuto-->
+		<item offset="63" id="3698" />	<!--Cherry Tree-->
+		<item offset="64" id="20713" />	<!--Excalipoor-->
+		<item offset="65" id="20714" />	<!--Excalipoor II-->
+		<item offset="66" id="26798" />	<!--Behemoth Masque-->
+		<item offset="67" id="26954" />	<!--Behemoth Suit-->
+		<item offset="68" id="26799" />	<!--Behe. Masque +1-->
+		<item offset="69" id="26955" />	<!--Behemoth Suit +1-->
+		<item offset="70" id="3706" />	<!--Vana'clock-->
+		<item offset="71" id="26956" />	<!--Poroggo Coat-->
+		<item offset="72" id="26957" />	<!--Poroggo Coat +1-->
+		<item offset="73" id="3705" />	<!--Far East Hearth-->
+		<item offset="74" id="26964" />	<!--Pupil's Camisa-->
+		<item offset="75" id="26965" />	<!--Ta Moko-->
+		<item offset="76" id="27291" />	<!--Swimming Togs-->
+		<item offset="77" id="26967" />	<!--Cossie Top-->
+		<item offset="78" id="27293" />	<!--Cossie Bottom-->
+		<item offset="79" id="26966" />	<!--Ta Moko +1-->
+		<item offset="80" id="27292" />	<!--Swimming Togs +1-->
+		<item offset="81" id="26968" />	<!--Cossie Top +1-->
+		<item offset="82" id="27294" />	<!--Cossie Bottom +1-->
+		<item offset="83" id="21153" />	<!--Malice Masher-->
+		<item offset="84" id="21154" />	<!--Malice Masher +1-->
+		<item offset="85" id="21086" />	<!--Heartstopper-->
+		<item offset="86" id="21087" />	<!--Heartstopper +1-->
+		<item offset="87" id="25606" />	<!--Agent Hood-->
+		<item offset="88" id="26974" />	<!--Agent Coat-->
+		<item offset="89" id="27111" />	<!--Agent Cuffs-->
+		<item offset="90" id="27296" />	<!--Agent Pants-->
+		<item offset="91" id="27467" />	<!--Agent Boots-->
+		<item offset="92" id="25607" />	<!--Starlet Flower-->
+		<item offset="93" id="26975" />	<!--Starlet Jabot-->
+		<item offset="94" id="27112" />	<!--Starlet Gloves-->
+		<item offset="95" id="27297" />	<!--Starlet Skirt-->
+		<item offset="96" id="27468" />	<!--Starlet Boots-->
+		<item offset="97" id="14195" />	<!--Waders-->
+		<item offset="98" id="14830" />	<!--Carpenter's Gloves-->
+		<item offset="99" id="14831" />	<!--Smithy's Mitts-->
+		<item offset="100" id="13945" />	<!--Shaded Specs.-->
+		<item offset="101" id="13946" />	<!--Magnifying Specs.-->
+		<item offset="102" id="14832" />	<!--Tanner's Gloves-->
+		<item offset="103" id="13947" />	<!--Protective Specs.-->
+		<item offset="104" id="17058" />	<!--Caduceus-->
+		<item offset="105" id="13948" />	<!--Chef's Hat-->
+		<item offset="106" id="14400" />	<!--Fisherman's Apron-->
+		<item offset="107" id="14392" />	<!--Carpenter's Apron-->
+		<item offset="108" id="14393" />	<!--Blacksmith's Apn.-->
+		<item offset="109" id="14394" />	<!--Goldsmith's Apron-->
+		<item offset="110" id="14395" />	<!--Weaver's Apron-->
+		<item offset="111" id="14396" />	<!--Tanner's Apron-->
+		<item offset="112" id="14397" />	<!--Boneworker's Apn.-->
+		<item offset="113" id="14398" />	<!--Alchemist's Apron-->
+		<item offset="114" id="14399" />	<!--Culinarian's Apron-->
+		<item offset="115" id="11337" />	<!--Fisherman's Smock-->
+		<item offset="116" id="11329" />	<!--Carpenter's Smock-->
+		<item offset="117" id="11330" />	<!--Blksmith. Smock-->
+		<item offset="118" id="11331" />	<!--Goldsmith's Smock-->
+		<item offset="119" id="11332" />	<!--Weaver's Smock-->
+		<item offset="120" id="11333" />	<!--Tanner's Smock-->
+		<item offset="121" id="11334" />	<!--Bonewrk. Smock-->
+		<item offset="122" id="11335" />	<!--Alchemist's Smock-->
+		<item offset="123" id="11336" />	<!--Culinarian's Smock-->
+		<item offset="124" id="15819" />	<!--Carpenter's Ring-->
+		<item offset="125" id="15820" />	<!--Smith's Ring-->
+		<item offset="126" id="15821" />	<!--Goldsmith's Ring-->
+		<item offset="127" id="15822" />	<!--Tailor's Ring-->
+		<item offset="128" id="15823" />	<!--Tanner's Ring-->
+		<item offset="129" id="15824" />	<!--Bonecrafter's Ring-->
+		<item offset="130" id="15825" />	<!--Alchemist's Ring-->
+		<item offset="131" id="15826" />	<!--Chef's Ring-->
+		<item offset="132" id="3670" />	<!--Net and Lure-->
+		<item offset="133" id="3672" />	<!--Carpenter's Kit-->
+		<item offset="134" id="3661" />	<!--Stone Hearth-->
+		<item offset="135" id="3595" />	<!--Gemscope-->
+		<item offset="136" id="3665" />	<!--Spinning Wheel-->
+		<item offset="137" id="3668" />	<!--Hide Stretcher-->
+		<item offset="138" id="3663" />	<!--Bonecraft Tools-->
+		<item offset="139" id="3674" />	<!--Alembic-->
+		<item offset="140" id="3667" />	<!--Brass Crock-->
+		<item offset="141" id="191" />	<!--Fishing Hole Map-->
+		<item offset="142" id="28" />	<!--Drawing Desk-->
+		<item offset="143" id="153" />	<!--Mastersmith Anvil-->
+		<item offset="144" id="151" />	<!--Fool's Gold-->
+		<item offset="145" id="198" />	<!--Gilt Tapestry-->
+		<item offset="146" id="202" />	<!--Golden Fleece-->
+		<item offset="147" id="142" />	<!--Drogaroga's Fang-->
+		<item offset="148" id="134" />	<!--Emeralda-->
+		<item offset="149" id="137" />	<!--Cordon Bleu Set-->
+		<item offset="150" id="340" />	<!--Fisherman's Sign-->
+		<item offset="151" id="341" />	<!--Carpenter's Sign-->
+		<item offset="152" id="334" />	<!--Blacksmith's Sign-->
+		<item offset="153" id="335" />	<!--Goldsmith's Sign-->
+		<item offset="154" id="337" />	<!--Weaver's Sign-->
+		<item offset="155" id="339" />	<!--Tanner's Sign-->
+		<item offset="156" id="336" />	<!--Boneworker's Sign-->
+		<item offset="157" id="342" />	<!--Alchemist's Sign-->
+		<item offset="158" id="338" />	<!--Culinarian's Sign-->
+		<item offset="159" id="3631" />	<!--Fishermn. Stall-->
+		<item offset="160" id="3632" />	<!--Carpntr. Stall-->
+		<item offset="161" id="3625" />	<!--Blksmth. Stall-->
+		<item offset="162" id="3626" />	<!--Gldsmth. Stall-->
+		<item offset="163" id="3628" />	<!--Weavers' Stall-->
+		<item offset="164" id="3630" />	<!--Tanners' Stall-->
+		<item offset="165" id="3627" />	<!--Bonewrk. Stall-->
+		<item offset="166" id="3633" />	<!--Alchmsts. Stall-->
+		<item offset="167" id="3629" />	<!--Culinary Stall-->
+		<item offset="168" id="25632" />	<!--Carbie Cap-->
+		<item offset="169" id="25633" />	<!--Carbie Cap +1-->
+		<item offset="170" id="25604" />	<!--Buffalo Cap-->
+		<item offset="171" id="25713" />	<!--Track Shirt-->
+		<item offset="172" id="27325" />	<!--Track Pants-->
+		<item offset="173" id="25714" />	<!--Track Shirt +1-->
+		<item offset="174" id="27326" />	<!--Track Pants +1-->
+		<item offset="175" id="3651" />	<!--Harvest Pastry-->
+		<item offset="176" id="25711" />	<!--Botulus Suit-->
+		<item offset="177" id="25712" />	<!--Botulus Suit +1-->
+		<item offset="178" id="10925" />	<!--Fisher's Torque-->
+		<item offset="179" id="10948" />	<!--Carver's Torque-->
+		<item offset="180" id="10949" />	<!--Smithy's Torque-->
+		<item offset="181" id="10950" />	<!--Goldsm. Torque-->
+		<item offset="182" id="10951" />	<!--Weaver's Torque-->
+		<item offset="183" id="10952" />	<!--Tanner's Torque-->
+		<item offset="184" id="10953" />	<!--Bone. Torque-->
+		<item offset="185" id="10954" />	<!--Alchemst. Torque-->
+		<item offset="186" id="10955" />	<!--Culin. Torque-->
+		<item offset="187" id="25657" />	<!--Wyrmking Masque-->
+		<item offset="188" id="25756" />	<!--Wyrmking Suit-->
+		<item offset="189" id="25658" />	<!--Wyrm. Masque +1-->
+		<item offset="190" id="25757" />	<!--Wyrmking Suit +1-->
+		<item offset="191" id="25909" />	<!--Morbol Subligar-->
+	</slip>
+	<slip id="29331">		<!--Storage Slip 20-->
+		<item offset="0" id="26740" />	<!--Boii Mask-->
+		<item offset="1" id="26898" />	<!--Boii Lorica-->
+		<item offset="2" id="27052" />	<!--Boii Mufflers-->
+		<item offset="3" id="27237" />	<!--Boii Cuisses-->
+		<item offset="4" id="27411" />	<!--Boii Calligae-->
+		<item offset="5" id="26742" />	<!--Bhikku Crown-->
+		<item offset="6" id="26900" />	<!--Bhikku Cyclas-->
+		<item offset="7" id="27054" />	<!--Bhikku Gloves-->
+		<item offset="8" id="27239" />	<!--Bhikku Hose-->
+		<item offset="9" id="27413" />	<!--Bhikku Gaiters-->
+		<item offset="10" id="26744" />	<!--Ebers Cap-->
+		<item offset="11" id="26902" />	<!--Ebers Bliaut-->
+		<item offset="12" id="27056" />	<!--Ebers Mitts-->
+		<item offset="13" id="27241" />	<!--Ebers Pantaloons-->
+		<item offset="14" id="27415" />	<!--Ebers Duckbills-->
+		<item offset="15" id="26746" />	<!--Wicce Petasos-->
+		<item offset="16" id="26904" />	<!--Wicce Coat-->
+		<item offset="17" id="27058" />	<!--Wicce Gloves-->
+		<item offset="18" id="27243" />	<!--Wicce Chausses-->
+		<item offset="19" id="27417" />	<!--Wicce Sabots-->
+		<item offset="20" id="26748" />	<!--Lethargy Chappel-->
+		<item offset="21" id="26906" />	<!--Lethargy Sayon-->
+		<item offset="22" id="27060" />	<!--Leth. Gantherots-->
+		<item offset="23" id="27245" />	<!--Leth. Fuseau-->
+		<item offset="24" id="27419" />	<!--Leth. Houseaux-->
+		<item offset="25" id="26750" />	<!--Skulker's Bonnet-->
+		<item offset="26" id="26908" />	<!--Skulker's Vest-->
+		<item offset="27" id="27062" />	<!--Skulker's Armlets-->
+		<item offset="28" id="27247" />	<!--Skulker's Culottes-->
+		<item offset="29" id="27421" />	<!--Skulk. Poulaines-->
+		<item offset="30" id="26752" />	<!--Chevalier's Armet-->
+		<item offset="31" id="26910" />	<!--Chev. Cuirass-->
+		<item offset="32" id="27064" />	<!--Chev. Gauntlets-->
+		<item offset="33" id="27249" />	<!--Chevalier's Cuisses-->
+		<item offset="34" id="27423" />	<!--Chev. Sabatons-->
+		<item offset="35" id="26754" />	<!--Heathen's Burgeonet-->
+		<item offset="36" id="26912" />	<!--Heathen's Cuirass-->
+		<item offset="37" id="27066" />	<!--Heath. Gauntlets-->
+		<item offset="38" id="27251" />	<!--Heath. Flanchard-->
+		<item offset="39" id="27425" />	<!--Heath. Sollerets-->
+		<item offset="40" id="26756" />	<!--Nukumi Cabasset-->
+		<item offset="41" id="26914" />	<!--Nukumi Gausape-->
+		<item offset="42" id="27068" />	<!--Nukumi Manoplas-->
+		<item offset="43" id="27253" />	<!--Nukumi Quijotes-->
+		<item offset="44" id="27427" />	<!--Nukumi Ocreae-->
+		<item offset="45" id="26758" />	<!--Fili Calot-->
+		<item offset="46" id="26916" />	<!--Fili Hongreline-->
+		<item offset="47" id="27070" />	<!--Fili Manchettes-->
+		<item offset="48" id="27255" />	<!--Fili Rhingrave-->
+		<item offset="49" id="27429" />	<!--Fili Cothurnes-->
+		<item offset="50" id="26760" />	<!--Amini Gapette-->
+		<item offset="51" id="26918" />	<!--Amini Caban-->
+		<item offset="52" id="27072" />	<!--Amini Glovelettes-->
+		<item offset="53" id="27257" />	<!--Amini Bragues-->
+		<item offset="54" id="27431" />	<!--Amini Bottillons-->
+		<item offset="55" id="26762" />	<!--Kasuga Kabuto-->
+		<item offset="56" id="26920" />	<!--Kasuga Domaru-->
+		<item offset="57" id="27074" />	<!--Kasuga Kote-->
+		<item offset="58" id="27259" />	<!--Kasuga Haidate-->
+		<item offset="59" id="27433" />	<!--Kasuga Sune-Ate-->
+		<item offset="60" id="26764" />	<!--Hattori Zukin-->
+		<item offset="61" id="26922" />	<!--Hattori Ningi-->
+		<item offset="62" id="27076" />	<!--Hattori Tekko-->
+		<item offset="63" id="27261" />	<!--Hattori Hakama-->
+		<item offset="64" id="27435" />	<!--Hattori Kyahan-->
+		<item offset="65" id="26766" />	<!--Peltast's Mezail-->
+		<item offset="66" id="26924" />	<!--Peltast's Plackart-->
+		<item offset="67" id="27078" />	<!--Pel. Vambraces-->
+		<item offset="68" id="27263" />	<!--Peltast's Cuissots-->
+		<item offset="69" id="27437" />	<!--Pelt. Schynbalds-->
+		<item offset="70" id="26768" />	<!--Beckoner's Horn-->
+		<item offset="71" id="26926" />	<!--Beckoner's Doublet-->
+		<item offset="72" id="27080" />	<!--Beckoner's Bracers-->
+		<item offset="73" id="27265" />	<!--Beckoner's Spats-->
+		<item offset="74" id="27439" />	<!--Beck. Pigaches-->
+		<item offset="75" id="26770" />	<!--Hashishin Kavuk-->
+		<item offset="76" id="26928" />	<!--Hashishin Mintan-->
+		<item offset="77" id="27082" />	<!--Hashi. Bazubands-->
+		<item offset="78" id="27267" />	<!--Hashishin Tayt-->
+		<item offset="79" id="27441" />	<!--Hashishin Basmak-->
+		<item offset="80" id="26772" />	<!--Chass. Tricorne-->
+		<item offset="81" id="26930" />	<!--Chasseur's Frac-->
+		<item offset="82" id="27084" />	<!--Chasseur's Gants-->
+		<item offset="83" id="27269" />	<!--Chas. Culottes-->
+		<item offset="84" id="27443" />	<!--Chasseur's Bottes-->
+		<item offset="85" id="26774" />	<!--Karagoz Cappello-->
+		<item offset="86" id="26932" />	<!--Karagoz Farsetto-->
+		<item offset="87" id="27086" />	<!--Karagoz Guanti-->
+		<item offset="88" id="27271" />	<!--Karagoz Pantaloni-->
+		<item offset="89" id="27445" />	<!--Karagoz Scarpe-->
+		<item offset="90" id="26776" />	<!--Maculele Tiara-->
+		<item offset="91" id="26934" />	<!--Maculele Casaque-->
+		<item offset="92" id="27088" />	<!--Maculele Bangles-->
+		<item offset="93" id="27273" />	<!--Maculele Tights-->
+		<item offset="94" id="27447" />	<!--Macu. Toe Shoes-->
+		<item offset="95" id="26778" />	<!--Arbatel Bonnet-->
+		<item offset="96" id="26936" />	<!--Arbatel Gown-->
+		<item offset="97" id="27090" />	<!--Arbatel Bracers-->
+		<item offset="98" id="27275" />	<!--Arbatel Pants-->
+		<item offset="99" id="27449" />	<!--Arbatel Loafers-->
+		<item offset="100" id="26780" />	<!--Azimuth Hood-->
+		<item offset="101" id="26938" />	<!--Azimuth Coat-->
+		<item offset="102" id="27092" />	<!--Azimuth Gloves-->
+		<item offset="103" id="27277" />	<!--Azimuth Tights-->
+		<item offset="104" id="27451" />	<!--Azimuth Gaiters-->
+		<item offset="105" id="26782" />	<!--Erilaz Galea-->
+		<item offset="106" id="26940" />	<!--Erilaz Surcoat-->
+		<item offset="107" id="27094" />	<!--Erilaz Gauntlets-->
+		<item offset="108" id="27279" />	<!--Erilaz Leg Guards-->
+		<item offset="109" id="27453" />	<!--Erilaz Greaves-->
+	</slip>
+	<slip id="29332">		<!--Storage Slip 21-->
+		<item offset="0" id="26741" />	<!--Boii Mask +1-->
+		<item offset="1" id="26899" />	<!--Boii Lorica +1-->
+		<item offset="2" id="27053" />	<!--Boii Mufflers +1-->
+		<item offset="3" id="27238" />	<!--Boii Cuisses +1-->
+		<item offset="4" id="27412" />	<!--Boii Calligae +1-->
+		<item offset="5" id="26743" />	<!--Bhikku Crown +1-->
+		<item offset="6" id="26901" />	<!--Bhikku Cyclas +1-->
+		<item offset="7" id="27055" />	<!--Bhikku Gloves +1-->
+		<item offset="8" id="27240" />	<!--Bhikku Hose +1-->
+		<item offset="9" id="27414" />	<!--Bhikku Gaiters +1-->
+		<item offset="10" id="26745" />	<!--Ebers Cap +1-->
+		<item offset="11" id="26903" />	<!--Ebers Bliaut +1-->
+		<item offset="12" id="27057" />	<!--Ebers Mitts +1-->
+		<item offset="13" id="27242" />	<!--Ebers Pant. +1-->
+		<item offset="14" id="27416" />	<!--Ebers Duckbills +1-->
+		<item offset="15" id="26747" />	<!--Wicce Petasos +1-->
+		<item offset="16" id="26905" />	<!--Wicce Coat +1-->
+		<item offset="17" id="27059" />	<!--Wicce Gloves +1-->
+		<item offset="18" id="27244" />	<!--Wicce Chausses +1-->
+		<item offset="19" id="27418" />	<!--Wicce Sabots +1-->
+		<item offset="20" id="26749" />	<!--Leth. Chappel +1-->
+		<item offset="21" id="26907" />	<!--Lethargy Sayon +1-->
+		<item offset="22" id="27061" />	<!--Leth. Gantherots +1-->
+		<item offset="23" id="27246" />	<!--Leth. Fuseau +1-->
+		<item offset="24" id="27420" />	<!--Leth. Houseaux +1-->
+		<item offset="25" id="26751" />	<!--Skulker's Bonnet +1-->
+		<item offset="26" id="26909" />	<!--Skulker's Vest +1-->
+		<item offset="27" id="27063" />	<!--Skulk. Armlets +1-->
+		<item offset="28" id="27248" />	<!--Skulk. Culottes +1-->
+		<item offset="29" id="27422" />	<!--Skulk. Poulaines +1-->
+		<item offset="30" id="26753" />	<!--Chev. Armet +1-->
+		<item offset="31" id="26911" />	<!--Chev. Cuirass +1-->
+		<item offset="32" id="27065" />	<!--Chev. Gauntlets +1-->
+		<item offset="33" id="27250" />	<!--Chev. Cuisses +1-->
+		<item offset="34" id="27424" />	<!--Chev. Sabatons +1-->
+		<item offset="35" id="26755" />	<!--Heath. Burgeonet +1-->
+		<item offset="36" id="26913" />	<!--Heath. Cuirass +1-->
+		<item offset="37" id="27067" />	<!--Heath. Gauntlets +1-->
+		<item offset="38" id="27252" />	<!--Heath. Flanchard +1-->
+		<item offset="39" id="27426" />	<!--Heath. Sollerets +1-->
+		<item offset="40" id="26757" />	<!--Nuk. Cabasset +1-->
+		<item offset="41" id="26915" />	<!--Nukumi Gausape +1-->
+		<item offset="42" id="27069" />	<!--Nukumi Manoplas +1-->
+		<item offset="43" id="27254" />	<!--Nukumi Quijotes +1-->
+		<item offset="44" id="27428" />	<!--Nukumi Ocreae +1-->
+		<item offset="45" id="26759" />	<!--Fili Calot +1-->
+		<item offset="46" id="26917" />	<!--Fili Hongreline +1-->
+		<item offset="47" id="27071" />	<!--Fili Manchettes +1-->
+		<item offset="48" id="27256" />	<!--Fili Rhingrave +1-->
+		<item offset="49" id="27430" />	<!--Fili Cothurnes +1-->
+		<item offset="50" id="26761" />	<!--Amini Gapette +1-->
+		<item offset="51" id="26919" />	<!--Amini Caban +1-->
+		<item offset="52" id="27073" />	<!--Amini Glove. +1-->
+		<item offset="53" id="27258" />	<!--Amini Bragues +1-->
+		<item offset="54" id="27432" />	<!--Amini Bottillons +1-->
+		<item offset="55" id="26763" />	<!--Kasuga Kabuto +1-->
+		<item offset="56" id="26921" />	<!--Kasuga Domaru +1-->
+		<item offset="57" id="27075" />	<!--Kasuga Kote +1-->
+		<item offset="58" id="27260" />	<!--Kasuga Haidate +1-->
+		<item offset="59" id="27434" />	<!--Kas. Sune-Ate +1-->
+		<item offset="60" id="26765" />	<!--Hattori Zukin +1-->
+		<item offset="61" id="26923" />	<!--Hattori Ningi +1-->
+		<item offset="62" id="27077" />	<!--Hattori Tekko +1-->
+		<item offset="63" id="27262" />	<!--Hattori Hakama +1-->
+		<item offset="64" id="27436" />	<!--Hattori Kyahan +1-->
+		<item offset="65" id="26767" />	<!--Peltast's Mezail +1-->
+		<item offset="66" id="26925" />	<!--Pelt. Plackart +1-->
+		<item offset="67" id="27079" />	<!--Pel. Vambraces +1-->
+		<item offset="68" id="27264" />	<!--Pelt. Cuissots +1-->
+		<item offset="69" id="27438" />	<!--Pelt. Schyn. +1-->
+		<item offset="70" id="26769" />	<!--Beckoner's Horn +1-->
+		<item offset="71" id="26927" />	<!--Beck. Doublet +1-->
+		<item offset="72" id="27081" />	<!--Beck. Bracers +1-->
+		<item offset="73" id="27266" />	<!--Beck. Spats +1-->
+		<item offset="74" id="27440" />	<!--Beck. Pigaches +1-->
+		<item offset="75" id="26771" />	<!--Hashishin Kavuk +1-->
+		<item offset="76" id="26929" />	<!--Hashishin Mintan +1-->
+		<item offset="77" id="27083" />	<!--Hashi. Bazu. +1-->
+		<item offset="78" id="27268" />	<!--Hashishin Tayt +1-->
+		<item offset="79" id="27442" />	<!--Hashi. Basmak +1-->
+		<item offset="80" id="26773" />	<!--Chass. Tricorne +1-->
+		<item offset="81" id="26931" />	<!--Chasseur's Frac +1-->
+		<item offset="82" id="27085" />	<!--Chasseur's Gants +1-->
+		<item offset="83" id="27270" />	<!--Chas. Culottes +1-->
+		<item offset="84" id="27444" />	<!--Chass. Bottes +1-->
+		<item offset="85" id="26775" />	<!--Kara. Cappello +1-->
+		<item offset="86" id="26933" />	<!--Kara. Farsetto +1-->
+		<item offset="87" id="27087" />	<!--Karagoz Guanti +1-->
+		<item offset="88" id="27272" />	<!--Kara. Pantaloni +1-->
+		<item offset="89" id="27446" />	<!--Karagoz Scarpe +1-->
+		<item offset="90" id="26777" />	<!--Maculele Tiara +1-->
+		<item offset="91" id="26935" />	<!--Macu. Casaque +1-->
+		<item offset="92" id="27089" />	<!--Macu. Bangles +1-->
+		<item offset="93" id="27274" />	<!--Maculele Tights +1-->
+		<item offset="94" id="27448" />	<!--Macu. Toe Shoes +1-->
+		<item offset="95" id="26779" />	<!--Arbatel Bonnet +1-->
+		<item offset="96" id="26937" />	<!--Arbatel Gown +1-->
+		<item offset="97" id="27091" />	<!--Arbatel Bracers +1-->
+		<item offset="98" id="27276" />	<!--Arbatel Pants +1-->
+		<item offset="99" id="27450" />	<!--Arbatel Loafers +1-->
+		<item offset="100" id="26781" />	<!--Azimuth Hood +1-->
+		<item offset="101" id="26939" />	<!--Azimuth Coat +1-->
+		<item offset="102" id="27093" />	<!--Azimuth Gloves +1-->
+		<item offset="103" id="27278" />	<!--Azimuth Tights +1-->
+		<item offset="104" id="27452" />	<!--Azimuth Gaiters +1-->
+		<item offset="105" id="26783" />	<!--Erilaz Galea +1-->
+		<item offset="106" id="26941" />	<!--Erilaz Surcoat +1-->
+		<item offset="107" id="27095" />	<!--Erilaz Gauntlets +1-->
+		<item offset="108" id="27280" />	<!--Eri. Leg Guards +1-->
+		<item offset="109" id="27454" />	<!--Erilaz Greaves +1-->
+	</slip>
+	<slip id="29333">		<!--Storage Slip 22-->
+		<item offset="0" id="25639" />	<!--Korrigan Masque-->
+		<item offset="1" id="25715" />	<!--Korrigan Suit-->
+		<item offset="2" id="25638" />	<!--Pachy. Masque-->
+		<item offset="3" id="3707" />	<!--Murrey Grisaille-->
+		<item offset="4" id="3708" />	<!--Moss Gr. Grisaille-->
+		<item offset="5" id="21074" />	<!--Kupo Rod-->
+		<item offset="6" id="26406" />	<!--Kupo Shield-->
+		<item offset="7" id="25645" />	<!--Kupo Masque-->
+		<item offset="8" id="25726" />	<!--Kupo Suit-->
+		<item offset="9" id="25648" />	<!--Curm. Helmet-->
+		<item offset="10" id="25649" />	<!--Gazer's Helmet-->
+		<item offset="11" id="25650" />	<!--Retching Helmet-->
+		<item offset="12" id="25758" />	<!--Rhapsody Shirt-->
+		<item offset="13" id="25759" />	<!--Rhapsody Shirt +1-->
+		<item offset="14" id="25672" />	<!--Snoll Masque-->
+		<item offset="15" id="25673" />	<!--Snoll Masque +1-->
+		<item offset="16" id="282" />	<!--Yovra Replica-->
+		<item offset="17" id="279" />	<!--S. Lord Statue II-->
+		<item offset="18" id="280" />	<!--S. Lord Statue III-->
+		<item offset="19" id="268" />	<!--N. Moogle Statue-->
+		<item offset="20" id="25670" />	<!--Rarab Cap-->
+		<item offset="21" id="25671" />	<!--Rarab Cap +1-->
+		<item offset="22" id="26520" />	<!--Akitu Shirt-->
+		<item offset="23" id="25652" />	<!--Crab Cap-->
+		<item offset="24" id="25669" />	<!--Crab Cap +1-->
+		<item offset="25" id="22017" />	<!--Seika Uchiwa-->
+		<item offset="26" id="22018" />	<!--Seika Uchiwa +1-->
+		<item offset="27" id="25586" />	<!--Kakai Cap-->
+		<item offset="28" id="25587" />	<!--Kakai Cap +1-->
+		<item offset="29" id="10384" />	<!--Cumulus Masque-->
+		<item offset="30" id="10385" />	<!--Cumulus Masque +1-->
+		<item offset="31" id="22019" />	<!--Jingly Rod-->
+		<item offset="32" id="22020" />	<!--Jingly Rod +1-->
+		<item offset="33" id="25722" />	<!--Jubilee Shirt-->
+		<item offset="34" id="25585" />	<!--Bl. Chocobo Cap-->
+		<item offset="35" id="25776" />	<!--Bl. Chocobo Suit-->
+		<item offset="36" id="25677" />	<!--Arthro's Cap-->
+		<item offset="37" id="25678" />	<!--Arthro's Cap +1-->
+		<item offset="38" id="25675" />	<!--Wh. Rarab Cap-->
+		<item offset="39" id="25679" />	<!--Wh. Rarab Cap +1-->
+		<item offset="40" id="20668" />	<!--Firetongue-->
+		<item offset="41" id="20669" />	<!--Firetongue +1-->
+		<item offset="42" id="22069" />	<!--Hapy Staff-->
+		<item offset="43" id="25755" />	<!--Crustacean Shirt-->
+		<item offset="44" id="3722" />	<!--Lion Statue-->
+		<item offset="45" id="21608" />	<!--Onion Sword II-->
+		<item offset="46" id="3713" />	<!--Pot of Wards-->
+		<item offset="47" id="3714" />	<!--White Clematis-->
+		<item offset="48" id="3715" />	<!--Pink Clematis-->
+		<item offset="49" id="3717" />	<!--Birch Tree-->
+		<item offset="50" id="3727" />	<!--Mumor Statue-->
+		<item offset="51" id="3728" />	<!--Ullegore Statue-->
+		<item offset="52" id="20577" />	<!--Chicken Knife II-->
+		<item offset="53" id="3726" />	<!--Aphmau Statue-->
+		<item offset="54" id="20666" />	<!--Blizzard Brand-->
+		<item offset="55" id="20667" />	<!--Blizzard Brand +1-->
+		<item offset="56" id="21741" />	<!--Demonic Axe-->
+		<item offset="57" id="21609" />	<!--Save the Queen II-->
+		<item offset="58" id="3723" />	<!--Lilisette Statue-->
+		<item offset="59" id="26410" />	<!--Diamond Buckler-->
+		<item offset="60" id="26411" />	<!--Diamond Buckler +1-->
+		<item offset="61" id="25850" />	<!--Pink Subligar-->
+		<item offset="62" id="21509" />	<!--Premium Mogti-->
+		<item offset="63" id="3725" />	<!--Cornelia Statue-->
+		<item offset="64" id="3720" />	<!--Arciela Statue-->
+		<item offset="65" id="21658" />	<!--Brave Blade II-->
+		<item offset="66" id="26524" />	<!--Gil Nabber Shirt-->
+		<item offset="67" id="20665" />	<!--Kam'lanaut's Sword-->
+		<item offset="68" id="26412" />	<!--Kam'lanaut's Shield-->
+		<item offset="69" id="21965" />	<!--Zanmato-->
+		<item offset="70" id="21966" />	<!--Zanmato +1-->
+		<item offset="71" id="21967" />	<!--Melon Slicer-->
+		<item offset="72" id="25774" />	<!--Fancy Gilet-->
+		<item offset="73" id="25838" />	<!--Fancy Trunks-->
+		<item offset="74" id="25775" />	<!--Fancy Top-->
+		<item offset="75" id="25839" />	<!--Fancy Shorts-->
+		<item offset="76" id="3724" />	<!--Uka Statue-->
+		<item offset="77" id="3721" />	<!--Iroha Statue-->
+		<item offset="78" id="21682" />	<!--Lament-->
+		<item offset="79" id="22072" />	<!--Lamia Staff-->
+		<item offset="80" id="21820" />	<!--Lost Sickle-->
+		<item offset="81" id="21821" />	<!--Lost Sickle +1-->
+		<item offset="82" id="23731" />	<!--Ryl. Chocobo Beret-->
+		<item offset="83" id="26517" />	<!--Shadow Lord Shirt-->
+		<item offset="84" id="23730" />	<!--Karakul Cap-->
+		<item offset="85" id="20573" />	<!--Aern Dagger-->
+		<item offset="86" id="20674" />	<!--Aern Sword-->
+		<item offset="87" id="21742" />	<!--Aern Axe-->
+		<item offset="88" id="21860" />	<!--Aern Spear-->
+		<item offset="89" id="22065" />	<!--Aern Staff-->
+		<item offset="90" id="22039" />	<!--Floral Hagoita-->
+		<item offset="91" id="22124" />	<!--Artemis's Bow-->
+		<item offset="92" id="22132" />	<!--Artemis's Bow +1-->
+		<item offset="93" id="3719" />	<!--Prishe Statue II-->
+		<item offset="94" id="3738" />	<!--Eastern Umbrella-->
+		<item offset="95" id="26518" />	<!--Jody Shirt-->
+		<item offset="96" id="27623" />	<!--Jody Shield-->
+		<item offset="97" id="21867" />	<!--Sha Wujing's Lance-->
+		<item offset="98" id="21868" />	<!--Sha Wujing's La. +1-->
+		<item offset="99" id="22283" />	<!--Marvelous Cheer-->
+		<item offset="100" id="26516" />	<!--Citrullus Shirt-->
+		<item offset="101" id="20933" />	<!--Hotengeki-->
+		<item offset="102" id="20578" />	<!--Wind Knife-->
+		<item offset="103" id="20568" />	<!--Wind Knife +1-->
+		<item offset="104" id="3739" />	<!--Autumn Tree-->
+		<item offset="105" id="20569" />	<!--Esikuva-->
+		<item offset="106" id="20570" />	<!--Norgish Dagger-->
+		<item offset="107" id="22288" />	<!--Mandragora Pouch-->
+		<item offset="108" id="26352" />	<!--Moogle Sacoche-->
+		<item offset="109" id="23737" />	<!--Byakko Masque-->
+		<item offset="110" id="22282" />	<!--Grudge-->
+		<item offset="111" id="3740" />	<!--Model Synergy Furn.-->
+		<item offset="112" id="3741" />	<!--Model Syn. Furn. II-->
+		<item offset="113" id="26545" />	<!--Mithkabob Shirt-->
+		<item offset="114" id="21977" />	<!--Mutsunokami-->
+		<item offset="115" id="21978" />	<!--Mutsunokami +1-->
+		<item offset="116" id="3742" />	<!--Merc. Painting-->
+		<item offset="117" id="26519" />	<!--Mandragora Shirt-->
+		<item offset="118" id="26514" />	<!--Poroggo Fleece-->
+		<item offset="119" id="26515" />	<!--Poroggo Fleece +1-->
+		<item offset="120" id="3743" />	<!--Moogle Bed-->
+		<item offset="121" id="21636" />	<!--Nihility-->
+		<item offset="122" id="23753" />	<!--Sandogasa-->
+		<item offset="123" id="23754" />	<!--Sandogasa +1-->
+		<item offset="124" id="54" />	<!--Chocobo Commode-->
+		<item offset="125" id="25910" />	<!--Cait Sith Subligar-->
+		<item offset="126" id="20571" />	<!--Infiltrator-->
+		<item offset="127" id="23790" />	<!--Adenium Masque-->
+		<item offset="128" id="23791" />	<!--Adenium Suit-->
+		<item offset="129" id="26489" />	<!--Troth-->
+		<item offset="130" id="22153" />	<!--Silver Gun-->
+		<item offset="131" id="22154" />	<!--Silver Gun +1-->
+		<item offset="132" id="20574" />	<!--Aern Dagger II-->
+		<item offset="133" id="20675" />	<!--Aern Sword II-->
+		<item offset="134" id="21743" />	<!--Aern Axe II-->
+		<item offset="135" id="21861" />	<!--Aern Spear II-->
+		<item offset="136" id="22066" />	<!--Aern Staff II-->
+		<item offset="137" id="3748" />	<!--Leafkin Bed-->
+		<item offset="138" id="21638" />	<!--Extinction-->
+		<item offset="139" id="23800" />	<!--Cancrine Apron-->
+		<item offset="140" id="23801" />	<!--Cancrine Apron +1-->
+		<item offset="141" id="3749" />	<!--Chemistry Set-->
+		<item offset="142" id="3750" />	<!--Qiqirn Sack-->
+		<item offset="143" id="22045" />	<!--Feline Hagoita-->
+		<item offset="144" id="22046" />	<!--Feline Hagoita +1-->
+		<item offset="145" id="3751" />	<!--Besigiled Table-->
+		<item offset="146" id="26490" />	<!--Ark Shield-->
+		<item offset="147" id="26546" />	<!--Moogle Shirt-->
+		<item offset="148" id="22047" />	<!--Korrigan Mallet-->
+		<item offset="149" id="22048" />	<!--Adenium Mallet-->
+		<item offset="150" id="22049" />	<!--Citrullus Mallet-->
+		<item offset="151" id="23803" />	<!--Poroggo Cassock-->
+		<item offset="152" id="23804" />	<!--Poroggo Cass. +1-->
+		<item offset="153" id="22051" />	<!--Lycopodium Mallet-->
+		<item offset="154" id="22052" />	<!--Summer Uchiwa-->
+		<item offset="155" id="3752" />	<!--Colibri Bed-->
+		<item offset="156" id="23805" />	<!--Morbol Apron-->
+		<item offset="157" id="25911" />	<!--Denim Pants-->
+		<item offset="158" id="25912" />	<!--Denim Pants +1-->
+		<item offset="159" id="3753" />	<!--Blueblade Fell-->
+		<item offset="160" id="23806" />	<!--Vaquero Hat-->
+		<item offset="161" id="3754" />	<!--Kagami Mochi-->
+		<item offset="162" id="23810" />	<!--Knit Cap-->
+		<item offset="163" id="23811" />	<!--Knit Cap +1-->
+		<item offset="164" id="3755" />	<!--Prismatic Chest-->
+		<item offset="165" id="26496" />	<!--Ageist-->
+		<item offset="166" id="26497" />	<!--Regis-->
+		<item offset="167" id="21786" />	<!--Poison Axe-->
+		<item offset="168" id="21787" />	<!--Poison Axe +1-->
+		<item offset="169" id="21996" />	<!--Magician's Rod-->
+		<item offset="170" id="21997" />	<!--Magician's Rod +1-->
+		<item offset="171" id="23802" />	<!--Aucuba Crown-->
+		<item offset="172" id="25777" />	<!--Iratsugo Happi-->
+		<item offset="173" id="25778" />	<!--Iratsume Happi-->
+		<item offset="174" id="21933" />	<!--Yagyu Shortblade-->
+		<item offset="175" id="21934" />	<!--Yagyu Short. +1-->
+		<item offset="176" id="21993" />	<!--Erudite's Staff-->
+		<item offset="177" id="21994" />	<!--Erudite's Staff +1-->
+		<item offset="178" id="23866" />	<!--Yule Talisman-->
+		<item offset="179" id="20670" />	<!--Macana-->
+		<item offset="180" id="21537" />	<!--Lizard Fangs-->
+		<item offset="181" id="21538" />	<!--Lizard Fangs +1-->
+		<item offset="182" id="21572" />	<!--Esoteric Athame-->
+		<item offset="183" id="23870" />	<!--Eyre Cap-->
+		<item offset="184" id="21760" />	<!--Dispatcher's Axe-->
+		<item offset="185" id="23871" />	<!--Hebenus Gilet-->
+		<item offset="186" id="23872" />	<!--Hebenus Boxers-->
+		<item offset="187" id="23873" />	<!--Hebenus Top-->
+		<item offset="188" id="23874" />	<!--Hebenus Shorts-->
+		<item offset="189" id="20691" />	<!--Kyukoto-->
+		<item offset="190" id="23893" />	<!--Dhalmel Trousers-->
+	</slip>
+	<slip id="29334">		<!--Storage Slip 23-->
+		<item offset="0" id="25659" />	<!--Sulevia's Mask-->
+		<item offset="1" id="25745" />	<!--Sulevia's Plate.-->
+		<item offset="2" id="25800" />	<!--Sulevia's Gauntlets-->
+		<item offset="3" id="25858" />	<!--Sulevia's Cuisses-->
+		<item offset="4" id="25925" />	<!--Sulevia's Leggings-->
+		<item offset="5" id="25660" />	<!--Sulevia's Mask +1-->
+		<item offset="6" id="25746" />	<!--Sulevia's Plate. +1-->
+		<item offset="7" id="25801" />	<!--Sulev. Gauntlets +1-->
+		<item offset="8" id="25859" />	<!--Sulevi. Cuisses +1-->
+		<item offset="9" id="25926" />	<!--Sulev. Leggings +1-->
+		<item offset="10" id="25663" />	<!--Hizamaru Somen-->
+		<item offset="11" id="25749" />	<!--Hizamaru Haramaki-->
+		<item offset="12" id="25804" />	<!--Hizamaru Kote-->
+		<item offset="13" id="25862" />	<!--Hiza. Hizayoroi-->
+		<item offset="14" id="25929" />	<!--Hiza. Sune-Ate-->
+		<item offset="15" id="25664" />	<!--Hizamaru Somen +1-->
+		<item offset="16" id="25750" />	<!--Hiza. Haramaki +1-->
+		<item offset="17" id="25805" />	<!--Hizamaru Kote +1-->
+		<item offset="18" id="25863" />	<!--Hiza. Hizayoroi +1-->
+		<item offset="19" id="25930" />	<!--Hiza. Sune-Ate +1-->
+		<item offset="20" id="25665" />	<!--Inyanga Tiara-->
+		<item offset="21" id="25751" />	<!--Inyanga Jubbah-->
+		<item offset="22" id="25806" />	<!--Inyanga Dastanas-->
+		<item offset="23" id="25865" />	<!--Inyanga Shalwar-->
+		<item offset="24" id="25931" />	<!--Inyanga Crackows-->
+		<item offset="25" id="25666" />	<!--Inyanga Tiara +1-->
+		<item offset="26" id="25752" />	<!--Inyanga Jubbah +1-->
+		<item offset="27" id="25807" />	<!--Inyan. Dastanas +1-->
+		<item offset="28" id="25866" />	<!--Inyanga Shalwar +1-->
+		<item offset="29" id="25932" />	<!--Inyan. Crackows +1-->
+		<item offset="30" id="25661" />	<!--Meghanada Visor-->
+		<item offset="31" id="25747" />	<!--Meghanada Cuirie-->
+		<item offset="32" id="25802" />	<!--Meghanada Gloves-->
+		<item offset="33" id="25860" />	<!--Meg. Chausses-->
+		<item offset="34" id="25927" />	<!--Meg. Jambeaux-->
+		<item offset="35" id="25662" />	<!--Meghanada Visor +1-->
+		<item offset="36" id="25748" />	<!--Meg. Cuirie +1-->
+		<item offset="37" id="25803" />	<!--Meg. Gloves +1-->
+		<item offset="38" id="25861" />	<!--Meg. Chausses +1-->
+		<item offset="39" id="25928" />	<!--Meg. Jam. +1-->
+		<item offset="40" id="25667" />	<!--Jhakri Coronal-->
+		<item offset="41" id="25753" />	<!--Jhakri Robe-->
+		<item offset="42" id="25808" />	<!--Jhakri Cuffs-->
+		<item offset="43" id="25867" />	<!--Jhakri Slops-->
+		<item offset="44" id="25933" />	<!--Jhakri Pigaches-->
+		<item offset="45" id="25668" />	<!--Jhakri Coronal +1-->
+		<item offset="46" id="25754" />	<!--Jhakri Robe +1-->
+		<item offset="47" id="25809" />	<!--Jhakri Cuffs +1-->
+		<item offset="48" id="25868" />	<!--Jhakri Slops +1-->
+		<item offset="49" id="25934" />	<!--Jhakri Pigaches +1-->
+		<item offset="50" id="25579" />	<!--Flamma Zucchetto-->
+		<item offset="51" id="25779" />	<!--Flamma Korazin-->
+		<item offset="52" id="25818" />	<!--Flamma Manopolas-->
+		<item offset="53" id="25873" />	<!--Flamma Dirs-->
+		<item offset="54" id="25940" />	<!--Flamma Gambieras-->
+		<item offset="55" id="25580" />	<!--Flam. Zucchetto +1-->
+		<item offset="56" id="25780" />	<!--Flamma Korazin +1-->
+		<item offset="57" id="25819" />	<!--Flam. Manopolas +1-->
+		<item offset="58" id="25874" />	<!--Flamma Dirs +1-->
+		<item offset="59" id="25941" />	<!--Flam. Gambieras +1-->
+		<item offset="60" id="25590" />	<!--Tali'ah Turban-->
+		<item offset="61" id="25764" />	<!--Tali'ah Manteel-->
+		<item offset="62" id="25812" />	<!--Tali'ah Gages-->
+		<item offset="63" id="25871" />	<!--Tali'ah Seraweels-->
+		<item offset="64" id="25937" />	<!--Tali'ah Crackows-->
+		<item offset="65" id="25591" />	<!--Tali'ah Turban +1-->
+		<item offset="66" id="25765" />	<!--Tali'ah Manteel +1-->
+		<item offset="67" id="25813" />	<!--Tali'ah Gages +1-->
+		<item offset="68" id="25872" />	<!--Tali'ah Sera. +1-->
+		<item offset="69" id="25938" />	<!--Tali'ah Crackows +1-->
+		<item offset="70" id="25581" />	<!--Mummu Bonnet-->
+		<item offset="71" id="25781" />	<!--Mummu Jacket-->
+		<item offset="72" id="25820" />	<!--Mummu Wrists-->
+		<item offset="73" id="25875" />	<!--Mummu Kecks-->
+		<item offset="74" id="25942" />	<!--Mummu Gamashes-->
+		<item offset="75" id="25582" />	<!--Mummu Bonnet +1-->
+		<item offset="76" id="25782" />	<!--Mummu Jacket +1-->
+		<item offset="77" id="25821" />	<!--Mummu Wrists +1-->
+		<item offset="78" id="25876" />	<!--Mummu Kecks +1-->
+		<item offset="79" id="25943" />	<!--Mummu Gamash. +1-->
+		<item offset="80" id="25588" />	<!--Aya. Zucchetto-->
+		<item offset="81" id="25762" />	<!--Ayanmo Corazza-->
+		<item offset="82" id="25810" />	<!--Aya. Manopolas-->
+		<item offset="83" id="25869" />	<!--Ayanmo Cosciales-->
+		<item offset="84" id="25935" />	<!--Aya. Gambieras-->
+		<item offset="85" id="25589" />	<!--Aya. Zucchetto +1-->
+		<item offset="86" id="25763" />	<!--Ayanmo Corazza +1-->
+		<item offset="87" id="25811" />	<!--Aya. Manopolas +1-->
+		<item offset="88" id="25870" />	<!--Aya. Cosciales +1-->
+		<item offset="89" id="25936" />	<!--Aya. Gambieras +1-->
+		<item offset="90" id="25583" />	<!--Mallquis Chapeau-->
+		<item offset="91" id="25783" />	<!--Mallquis Saio-->
+		<item offset="92" id="25822" />	<!--Mallquis Cuffs-->
+		<item offset="93" id="25877" />	<!--Mallquis Trews-->
+		<item offset="94" id="25944" />	<!--Mallquis Clogs-->
+		<item offset="95" id="25584" />	<!--Mallquis Chapeau +1-->
+		<item offset="96" id="25784" />	<!--Mallquis Saio +1-->
+		<item offset="97" id="25823" />	<!--Mallquis Cuffs +1-->
+		<item offset="98" id="25878" />	<!--Mallquis Trews +1-->
+		<item offset="99" id="25945" />	<!--Mallquis Clogs +1-->
+		<item offset="100" id="25574" />	<!--Sulevia's Mask +2-->
+		<item offset="101" id="25790" />	<!--Sulevia's Plate. +2-->
+		<item offset="102" id="25828" />	<!--Sulev. Gauntlets +2-->
+		<item offset="103" id="25879" />	<!--Sulev. Cuisses +2-->
+		<item offset="104" id="25946" />	<!--Sulev. Leggings +2-->
+		<item offset="105" id="25575" />	<!--Meghanada Visor +2-->
+		<item offset="106" id="25791" />	<!--Meg. Cuirie +2-->
+		<item offset="107" id="25829" />	<!--Meg. Gloves +2-->
+		<item offset="108" id="25880" />	<!--Meg. Chausses +2-->
+		<item offset="109" id="25947" />	<!--Meg. Jam. +2-->
+		<item offset="110" id="25576" />	<!--Hiza. Somen +2-->
+		<item offset="111" id="25792" />	<!--Hiza. Haramaki +2-->
+		<item offset="112" id="25830" />	<!--Hizamaru Kote +2-->
+		<item offset="113" id="25881" />	<!--Hiza. Hizayoroi +2-->
+		<item offset="114" id="25948" />	<!--Hiza. Sune-Ate +2-->
+		<item offset="115" id="25577" />	<!--Inyanga Tiara +2-->
+		<item offset="116" id="25793" />	<!--Inyanga Jubbah +2-->
+		<item offset="117" id="25831" />	<!--Inyan. Dastanas +2-->
+		<item offset="118" id="25882" />	<!--Inyanga Shalwar +2-->
+		<item offset="119" id="25949" />	<!--Inyan. Crackows +2-->
+		<item offset="120" id="25578" />	<!--Jhakri Coronal +2-->
+		<item offset="121" id="25794" />	<!--Jhakri Robe +2-->
+		<item offset="122" id="25832" />	<!--Jhakri Cuffs +2-->
+		<item offset="123" id="25883" />	<!--Jhakri Slops +2-->
+		<item offset="124" id="25950" />	<!--Jhakri Pigaches +2-->
+		<item offset="125" id="26204" />	<!--Sulevia's Ring-->
+		<item offset="126" id="26205" />	<!--Meghanada Ring-->
+		<item offset="127" id="26206" />	<!--Hizamaru Ring-->
+		<item offset="128" id="26207" />	<!--Inyanga Ring-->
+		<item offset="129" id="26208" />	<!--Jhakri Ring-->
+		<item offset="130" id="25569" />	<!--Flam. Zucchetto +2-->
+		<item offset="131" id="25797" />	<!--Flamma Korazin +2-->
+		<item offset="132" id="25835" />	<!--Flam. Manopolas +2-->
+		<item offset="133" id="25886" />	<!--Flamma Dirs +2-->
+		<item offset="134" id="25953" />	<!--Flam. Gambieras +2-->
+		<item offset="135" id="25573" />	<!--Tali'ah Turban +2-->
+		<item offset="136" id="25796" />	<!--Tali'ah Manteel +2-->
+		<item offset="137" id="25834" />	<!--Tali'ah Gages +2-->
+		<item offset="138" id="25885" />	<!--Tali'ah Sera. +2-->
+		<item offset="139" id="25952" />	<!--Tali'ah Crackows +2-->
+		<item offset="140" id="25570" />	<!--Mummu Bonnet +2-->
+		<item offset="141" id="25798" />	<!--Mummu Jacket +2-->
+		<item offset="142" id="25836" />	<!--Mummu Wrists +2-->
+		<item offset="143" id="25887" />	<!--Mummu Kecks +2-->
+		<item offset="144" id="25954" />	<!--Mummu Gamash. +2-->
+		<item offset="145" id="25572" />	<!--Aya. Zucchetto +2-->
+		<item offset="146" id="25795" />	<!--Ayanmo Corazza +2-->
+		<item offset="147" id="25833" />	<!--Aya. Manopolas +2-->
+		<item offset="148" id="25884" />	<!--Aya. Cosciales +2-->
+		<item offset="149" id="25951" />	<!--Aya. Gambieras +2-->
+		<item offset="150" id="25571" />	<!--Mall. Chapeau +2-->
+		<item offset="151" id="25799" />	<!--Mallquis Saio +2-->
+		<item offset="152" id="25837" />	<!--Mallquis Cuffs +2-->
+		<item offset="153" id="25888" />	<!--Mallquis Trews +2-->
+		<item offset="154" id="25955" />	<!--Mallquis Clogs +2-->
+		<item offset="155" id="26211" />	<!--Flamma Ring-->
+		<item offset="156" id="26210" />	<!--Tali'ah Ring-->
+		<item offset="157" id="26212" />	<!--Mummu Ring-->
+		<item offset="158" id="26209" />	<!--Ayanmo Ring-->
+		<item offset="159" id="26213" />	<!--Mallquis Ring-->
+		<item offset="160" id="21863" />	<!--Tzee Xicu's Blade-->
+		<item offset="161" id="22004" />	<!--Soulflayer's Wand-->
+		<item offset="162" id="21744" />	<!--Gramk's Axe-->
+		<item offset="163" id="21272" />	<!--Troll Gun-->
+		<item offset="164" id="20576" />	<!--Qutrub Knife-->
+		<item offset="165" id="21761" />	<!--Za'Dha Chopper-->
+		<item offset="166" id="26409" />	<!--Dullahan Shield-->
+		<item offset="167" id="22070" />	<!--Ranine Staff-->
+		<item offset="168" id="21681" />	<!--Ophidian Sword-->
+		<item offset="169" id="22005" />	<!--Burrower's Wand-->
+		<item offset="170" id="21745" />	<!--Dullahan Axe-->
+		<item offset="171" id="22068" />	<!--Savage. Pole-->
+		<item offset="172" id="21759" />	<!--Autarch's Axe-->
+		<item offset="173" id="21770" />	<!--Helgoland-->
+		<item offset="174" id="22067" />	<!--Levin-->
+		<item offset="175" id="21680" />	<!--Goujian-->
+		<item offset="176" id="22071" />	<!--Profane Staff-->
+	</slip>
+	<slip id="29335">		<!--Storage Slip 24-->
+		<item offset="0" id="23040" />	<!--Pummeler's Mask +2-->
+		<item offset="1" id="23107" />	<!--Pumm. Lorica +2-->
+		<item offset="2" id="23174" />	<!--Pumm. Mufflers +2-->
+		<item offset="3" id="23241" />	<!--Pumm. Cuisses +2-->
+		<item offset="4" id="23308" />	<!--Pumm. Calligae +2-->
+		<item offset="5" id="23041" />	<!--Anch. Crown +2-->
+		<item offset="6" id="23108" />	<!--Anch. Cyclas +2-->
+		<item offset="7" id="23175" />	<!--Anchor. Gloves +2-->
+		<item offset="8" id="23242" />	<!--Anch. Hose +2-->
+		<item offset="9" id="23309" />	<!--Anch. Gaiters +2-->
+		<item offset="10" id="23042" />	<!--Theophany Cap +2-->
+		<item offset="11" id="23109" />	<!--Theo. Bliaut +2-->
+		<item offset="12" id="23176" />	<!--Theophany Mitts +2-->
+		<item offset="13" id="23243" />	<!--Th. Pantaloons +2-->
+		<item offset="14" id="23310" />	<!--Theo. Duckbills +2-->
+		<item offset="15" id="23043" />	<!--Spae. Petasos +2-->
+		<item offset="16" id="23110" />	<!--Spaekona's Coat +2-->
+		<item offset="17" id="23177" />	<!--Spae. Gloves +2-->
+		<item offset="18" id="23244" />	<!--Spae. Tonban +2-->
+		<item offset="19" id="23311" />	<!--Spae. Sabots +2-->
+		<item offset="20" id="23044" />	<!--Atro. Chapeau +2-->
+		<item offset="21" id="23111" />	<!--Atrophy Tabard +2-->
+		<item offset="22" id="23178" />	<!--Atrophy Gloves +2-->
+		<item offset="23" id="23245" />	<!--Atrophy Tights +2-->
+		<item offset="24" id="23312" />	<!--Atro. Boots +2-->
+		<item offset="25" id="23045" />	<!--Pill. Bonnet +2-->
+		<item offset="26" id="23112" />	<!--Pillager's Vest +2-->
+		<item offset="27" id="23179" />	<!--Pill. Armlets +2-->
+		<item offset="28" id="23246" />	<!--Pill. Culottes +2-->
+		<item offset="29" id="23313" />	<!--Pill. Poulaines +2-->
+		<item offset="30" id="23046" />	<!--Rev. Coronet +2-->
+		<item offset="31" id="23113" />	<!--Rev. Surcoat +2-->
+		<item offset="32" id="23180" />	<!--Rev. Gauntlets +2-->
+		<item offset="33" id="23247" />	<!--Rev. Breeches +2-->
+		<item offset="34" id="23314" />	<!--Rev. Leggings +2-->
+		<item offset="35" id="23047" />	<!--Ig. Burgeonet +2-->
+		<item offset="36" id="23114" />	<!--Ignominy Cuirass +2-->
+		<item offset="37" id="23181" />	<!--Ig. Gauntlets +2-->
+		<item offset="38" id="23248" />	<!--Ig. Flanchard +2-->
+		<item offset="39" id="23315" />	<!--Ig. Sollerets +2-->
+		<item offset="40" id="23048" />	<!--Totemic Helm +2-->
+		<item offset="41" id="23115" />	<!--Tot. Jackcoat +2-->
+		<item offset="42" id="23182" />	<!--Totemic Gloves +2-->
+		<item offset="43" id="23249" />	<!--Tot. Trousers +2-->
+		<item offset="44" id="23316" />	<!--Tot. Gaiters +2-->
+		<item offset="45" id="23049" />	<!--Brioso Roundlet +2-->
+		<item offset="46" id="23116" />	<!--Brioso Justau. +2-->
+		<item offset="47" id="23183" />	<!--Brioso Cuffs +2-->
+		<item offset="48" id="23250" />	<!--Brioso Cannions +2-->
+		<item offset="49" id="23317" />	<!--Brioso Slippers +2-->
+		<item offset="50" id="23050" />	<!--Orion Beret +2-->
+		<item offset="51" id="23117" />	<!--Orion Jerkin +2-->
+		<item offset="52" id="23184" />	<!--Orion Bracers +2-->
+		<item offset="53" id="23251" />	<!--Orion Braccae +2-->
+		<item offset="54" id="23318" />	<!--Orion Socks +2-->
+		<item offset="55" id="23051" />	<!--Wakido Kabuto +2-->
+		<item offset="56" id="23118" />	<!--Wakido Domaru +2-->
+		<item offset="57" id="23185" />	<!--Wakido Kote +2-->
+		<item offset="58" id="23252" />	<!--Wakido Haidate +2-->
+		<item offset="59" id="23319" />	<!--Wakido Sune. +2-->
+		<item offset="60" id="23052" />	<!--Hachiya Hatsu. +2-->
+		<item offset="61" id="23119" />	<!--Hachiya Chain. +2-->
+		<item offset="62" id="23186" />	<!--Hachiya Tekko +2-->
+		<item offset="63" id="23253" />	<!--Hachiya Hakama +2-->
+		<item offset="64" id="23320" />	<!--Hachiya Kyahan +2-->
+		<item offset="65" id="23053" />	<!--Vishap Armet +2-->
+		<item offset="66" id="23120" />	<!--Vishap Mail +2-->
+		<item offset="67" id="23187" />	<!--Vis. Fng. Gaunt. +2-->
+		<item offset="68" id="23254" />	<!--Vishap Brais +2-->
+		<item offset="69" id="23321" />	<!--Vishap Greaves +2-->
+		<item offset="70" id="23054" />	<!--Convoker's Horn +2-->
+		<item offset="71" id="23121" />	<!--Con. Doublet +2-->
+		<item offset="72" id="23188" />	<!--Convo. Bracers +2-->
+		<item offset="73" id="23255" />	<!--Convo. Spats +2-->
+		<item offset="74" id="23322" />	<!--Convo. Pigaches +2-->
+		<item offset="75" id="23055" />	<!--Assim. Keffiyeh +2-->
+		<item offset="76" id="23122" />	<!--Assim. Jubbah +2-->
+		<item offset="77" id="23189" />	<!--Assim. Bazu. +2-->
+		<item offset="78" id="23256" />	<!--Assim. Shalwar +2-->
+		<item offset="79" id="23323" />	<!--Assim. Charuqs +2-->
+		<item offset="80" id="23056" />	<!--Laksa. Tricorne +2-->
+		<item offset="81" id="23123" />	<!--Laksa. Frac +2-->
+		<item offset="82" id="23190" />	<!--Laksa. Gants +2-->
+		<item offset="83" id="23257" />	<!--Laksa. Trews +2-->
+		<item offset="84" id="23324" />	<!--Laksa. Bottes +2-->
+		<item offset="85" id="23057" />	<!--Foire Taj +2-->
+		<item offset="86" id="23124" />	<!--Foire Tobe +2-->
+		<item offset="87" id="23191" />	<!--Foire Dastanas +2-->
+		<item offset="88" id="23258" />	<!--Foire Churidars +2-->
+		<item offset="89" id="23325" />	<!--Foire Babouches +2-->
+		<item offset="90" id="23058" />	<!--Maxixi Tiara +2-->
+		<item offset="91" id="23125" />	<!--Maxixi Casaque +2-->
+		<item offset="92" id="23192" />	<!--Maxixi Bangles +2-->
+		<item offset="93" id="23259" />	<!--Maxixi Tights +2-->
+		<item offset="94" id="23326" />	<!--Maxixi Toe Shoes +2-->
+		<item offset="95" id="23059" />	<!--Maxixi Tiara +2-->
+		<item offset="96" id="23126" />	<!--Maxixi Casaque +2-->
+		<item offset="97" id="23193" />	<!--Maxixi Bangles +2-->
+		<item offset="98" id="23260" />	<!--Maxixi Tights +2-->
+		<item offset="99" id="23327" />	<!--Maxixi Toe Shoes +2-->
+		<item offset="100" id="23060" />	<!--Acad. Mortar. +2-->
+		<item offset="101" id="23127" />	<!--Acad. Gown +2-->
+		<item offset="102" id="23194" />	<!--Acad. Bracers +2-->
+		<item offset="103" id="23261" />	<!--Acad. Pants +2-->
+		<item offset="104" id="23328" />	<!--Acad. Loafers +2-->
+		<item offset="105" id="23061" />	<!--Geo. Galero +2-->
+		<item offset="106" id="23128" />	<!--Geomancy Tunic +2-->
+		<item offset="107" id="23195" />	<!--Geo. Mitaines +2-->
+		<item offset="108" id="23262" />	<!--Geomancy Pants +2-->
+		<item offset="109" id="23329" />	<!--Geo. Sandals +2-->
+		<item offset="110" id="23062" />	<!--Rune. Bandeau +2-->
+		<item offset="111" id="23129" />	<!--Runeist Coat +2-->
+		<item offset="112" id="23196" />	<!--Runeist Mitons +2-->
+		<item offset="113" id="23263" />	<!--Rune. Trousers +2-->
+		<item offset="114" id="23330" />	<!--Runeist Bottes +2-->
+	</slip>
+	<slip id="29336">		<!--Storage Slip 25-->
+		<item offset="0" id="23375" />	<!--Pummeler's Mask +3-->
+		<item offset="1" id="23442" />	<!--Pumm. Lorica +3-->
+		<item offset="2" id="23509" />	<!--Pumm. Mufflers +3-->
+		<item offset="3" id="23576" />	<!--Pumm. Cuisses +3-->
+		<item offset="4" id="23643" />	<!--Pumm. Calligae +3-->
+		<item offset="5" id="23376" />	<!--Anch. Crown +3-->
+		<item offset="6" id="23443" />	<!--Anch. Cyclas +3-->
+		<item offset="7" id="23510" />	<!--Anchor. Gloves +3-->
+		<item offset="8" id="23577" />	<!--Anch. Hose +3-->
+		<item offset="9" id="23644" />	<!--Anch. Gaiters +3-->
+		<item offset="10" id="23377" />	<!--Theophany Cap +3-->
+		<item offset="11" id="23444" />	<!--Theo. Bliaut +3-->
+		<item offset="12" id="23511" />	<!--Theophany Mitts +3-->
+		<item offset="13" id="23578" />	<!--Th. Pant. +3-->
+		<item offset="14" id="23645" />	<!--Theo. Duckbills +3-->
+		<item offset="15" id="23378" />	<!--Spae. Petasos +3-->
+		<item offset="16" id="23445" />	<!--Spaekona's Coat +3-->
+		<item offset="17" id="23512" />	<!--Spae. Gloves +3-->
+		<item offset="18" id="23579" />	<!--Spae. Tonban +3-->
+		<item offset="19" id="23646" />	<!--Spae. Sabots +3-->
+		<item offset="20" id="23379" />	<!--Atrophy Chapeau +3-->
+		<item offset="21" id="23446" />	<!--Atrophy Tabard +3-->
+		<item offset="22" id="23513" />	<!--Atrophy Gloves +3-->
+		<item offset="23" id="23580" />	<!--Atrophy Tights +3-->
+		<item offset="24" id="23647" />	<!--Atro. Boots +3-->
+		<item offset="25" id="23380" />	<!--Pill. Bonnet +3-->
+		<item offset="26" id="23447" />	<!--Pillager's Vest +3-->
+		<item offset="27" id="23514" />	<!--Pill. Armlets +3-->
+		<item offset="28" id="23581" />	<!--Pill. Culottes +3-->
+		<item offset="29" id="23648" />	<!--Pill. Poulaines +3-->
+		<item offset="30" id="23381" />	<!--Rev. Coronet +3-->
+		<item offset="31" id="23448" />	<!--Rev. Surcoat +3-->
+		<item offset="32" id="23515" />	<!--Rev. Gauntlets +3-->
+		<item offset="33" id="23582" />	<!--Rev. Breeches +3-->
+		<item offset="34" id="23649" />	<!--Rev. Leggings +3-->
+		<item offset="35" id="23382" />	<!--Ig. Burgeonet +3-->
+		<item offset="36" id="23449" />	<!--Ignominy Cuirass +3-->
+		<item offset="37" id="23516" />	<!--Ig. Gauntlets +3-->
+		<item offset="38" id="23583" />	<!--Ig. Flanchard +3-->
+		<item offset="39" id="23650" />	<!--Ig. Sollerets +3-->
+		<item offset="40" id="23383" />	<!--Totemic Helm +3-->
+		<item offset="41" id="23450" />	<!--Tot. Jackcoat +3-->
+		<item offset="42" id="23517" />	<!--Totemic Gloves +3-->
+		<item offset="43" id="23584" />	<!--Tot. Trousers +3-->
+		<item offset="44" id="23651" />	<!--Tot. Gaiters +3-->
+		<item offset="45" id="23384" />	<!--Brioso Roundlet +3-->
+		<item offset="46" id="23451" />	<!--Brioso Justau. +3-->
+		<item offset="47" id="23518" />	<!--Brioso Cuffs +3-->
+		<item offset="48" id="23585" />	<!--Brioso Cannions +3-->
+		<item offset="49" id="23652" />	<!--Brioso Slippers +3-->
+		<item offset="50" id="23385" />	<!--Orion Beret +3-->
+		<item offset="51" id="23452" />	<!--Orion Jerkin +3-->
+		<item offset="52" id="23519" />	<!--Orion Bracers +3-->
+		<item offset="53" id="23586" />	<!--Orion Braccae +3-->
+		<item offset="54" id="23653" />	<!--Orion Socks +3-->
+		<item offset="55" id="23386" />	<!--Wakido Kabuto +3-->
+		<item offset="56" id="23453" />	<!--Wakido Domaru +3-->
+		<item offset="57" id="23520" />	<!--Wakido Kote +3-->
+		<item offset="58" id="23587" />	<!--Wakido Haidate +3-->
+		<item offset="59" id="23654" />	<!--Wakido Sune. +3-->
+		<item offset="60" id="23387" />	<!--Hachiya Hatsu. +3-->
+		<item offset="61" id="23454" />	<!--Hachiya Chain. +3-->
+		<item offset="62" id="23521" />	<!--Hachiya Tekko +3-->
+		<item offset="63" id="23588" />	<!--Hachiya Hakama +3-->
+		<item offset="64" id="23655" />	<!--Hachiya Kyahan +3-->
+		<item offset="65" id="23388" />	<!--Vishap Armet +3-->
+		<item offset="66" id="23455" />	<!--Vishap Mail +3-->
+		<item offset="67" id="23522" />	<!--Vis. Fng. Gaunt. +3-->
+		<item offset="68" id="23589" />	<!--Vishap Brais +3-->
+		<item offset="69" id="23656" />	<!--Vishap Greaves +3-->
+		<item offset="70" id="23389" />	<!--Convoker's Horn +3-->
+		<item offset="71" id="23456" />	<!--Con. Doublet +3-->
+		<item offset="72" id="23523" />	<!--Convo. Bracers +3-->
+		<item offset="73" id="23590" />	<!--Convo. Spats +3-->
+		<item offset="74" id="23657" />	<!--Convo. Pigaches +3-->
+		<item offset="75" id="23390" />	<!--Assim. Keffiyeh +3-->
+		<item offset="76" id="23457" />	<!--Assim. Jubbah +3-->
+		<item offset="77" id="23524" />	<!--Assim. Bazu. +3-->
+		<item offset="78" id="23591" />	<!--Assim. Shalwar +3-->
+		<item offset="79" id="23658" />	<!--Assim. Charuqs +3-->
+		<item offset="80" id="23391" />	<!--Laksa. Tricorne +3-->
+		<item offset="81" id="23458" />	<!--Laksa. Frac +3-->
+		<item offset="82" id="23525" />	<!--Laksa. Gants +3-->
+		<item offset="83" id="23592" />	<!--Laksa. Trews +3-->
+		<item offset="84" id="23659" />	<!--Laksa. Bottes +3-->
+		<item offset="85" id="23392" />	<!--Foire Taj +3-->
+		<item offset="86" id="23459" />	<!--Foire Tobe +3-->
+		<item offset="87" id="23526" />	<!--Foire Dastanas +3-->
+		<item offset="88" id="23593" />	<!--Foire Churidars +3-->
+		<item offset="89" id="23660" />	<!--Foire Babouches +3-->
+		<item offset="90" id="23393" />	<!--Maxixi Tiara +3-->
+		<item offset="91" id="23460" />	<!--Maxixi Casaque +3-->
+		<item offset="92" id="23527" />	<!--Maxixi Bangles +3-->
+		<item offset="93" id="23594" />	<!--Maxixi Tights +3-->
+		<item offset="94" id="23661" />	<!--Maxixi Toe Shoes +3-->
+		<item offset="95" id="23394" />	<!--Maxixi Tiara +3-->
+		<item offset="96" id="23461" />	<!--Maxixi Casaque +3-->
+		<item offset="97" id="23528" />	<!--Maxixi Bangles +3-->
+		<item offset="98" id="23595" />	<!--Maxixi Tights +3-->
+		<item offset="99" id="23662" />	<!--Maxixi Toe Shoes +3-->
+		<item offset="100" id="23395" />	<!--Acad. Mortar. +3-->
+		<item offset="101" id="23462" />	<!--Acad. Gown +3-->
+		<item offset="102" id="23529" />	<!--Acad. Bracers +3-->
+		<item offset="103" id="23596" />	<!--Acad. Pants +3-->
+		<item offset="104" id="23663" />	<!--Acad. Loafers +3-->
+		<item offset="105" id="23396" />	<!--Geo. Galero +3-->
+		<item offset="106" id="23463" />	<!--Geomancy Tunic +3-->
+		<item offset="107" id="23530" />	<!--Geo. Mitaines +3-->
+		<item offset="108" id="23597" />	<!--Geomancy Pants +3-->
+		<item offset="109" id="23664" />	<!--Geo. Sandals +3-->
+		<item offset="110" id="23397" />	<!--Rune. Bandeau +3-->
+		<item offset="111" id="23464" />	<!--Runeist Coat +3-->
+		<item offset="112" id="23531" />	<!--Runeist Mitons +3-->
+		<item offset="113" id="23598" />	<!--Rune. Trousers +3-->
+		<item offset="114" id="23665" />	<!--Runeist Bottes +3-->
+	</slip>
+	<slip id="29337">		<!--Storage Slip 26-->
+		<item offset="0" id="23063" />	<!--Agoge Mask +2-->
+		<item offset="1" id="23130" />	<!--Agoge Lorica +2-->
+		<item offset="2" id="23197" />	<!--Agoge Mufflers +2-->
+		<item offset="3" id="23264" />	<!--Agoge Cuisses +2-->
+		<item offset="4" id="23331" />	<!--Agoge Calligae +2-->
+		<item offset="5" id="23064" />	<!--Hes. Crown +2-->
+		<item offset="6" id="23131" />	<!--Hes. Cyclas +2-->
+		<item offset="7" id="23198" />	<!--Hes. Gloves +2-->
+		<item offset="8" id="23265" />	<!--Hes. Hose +2-->
+		<item offset="9" id="23332" />	<!--Hes. Gaiters +2-->
+		<item offset="10" id="23065" />	<!--Piety Cap +2-->
+		<item offset="11" id="23132" />	<!--Piety Bliaut +2-->
+		<item offset="12" id="23199" />	<!--Piety Mitts +2-->
+		<item offset="13" id="23266" />	<!--Piety Pantaln. +2-->
+		<item offset="14" id="23333" />	<!--Piety Duckbills +2-->
+		<item offset="15" id="23066" />	<!--Arch. Petasos +2-->
+		<item offset="16" id="23133" />	<!--Arch. Coat +2-->
+		<item offset="17" id="23200" />	<!--Arch. Gloves +2-->
+		<item offset="18" id="23267" />	<!--Arch. Tonban +2-->
+		<item offset="19" id="23334" />	<!--Arch. Sabots +2-->
+		<item offset="20" id="23067" />	<!--Viti. Chapeau +2-->
+		<item offset="21" id="23134" />	<!--Viti. Tabard +2-->
+		<item offset="22" id="23201" />	<!--Viti. Gloves +2-->
+		<item offset="23" id="23268" />	<!--Viti. Tights +2-->
+		<item offset="24" id="23335" />	<!--Vitiation Boots +2-->
+		<item offset="25" id="23068" />	<!--Plun. Bonnet +2-->
+		<item offset="26" id="23135" />	<!--Plunderer's Vest +2-->
+		<item offset="27" id="23202" />	<!--Plun. Armlets +2-->
+		<item offset="28" id="23269" />	<!--Plun. Culottes +2-->
+		<item offset="29" id="23336" />	<!--Plun. Poulaines +2-->
+		<item offset="30" id="23069" />	<!--Cab. Coronet +2-->
+		<item offset="31" id="23136" />	<!--Cab. Surcoat +2-->
+		<item offset="32" id="23203" />	<!--Cab. Gauntlets +2-->
+		<item offset="33" id="23270" />	<!--Cab. Breeches +2-->
+		<item offset="34" id="23337" />	<!--Cab. Leggings +2-->
+		<item offset="35" id="23070" />	<!--Fall. Burgeonet +2-->
+		<item offset="36" id="23137" />	<!--Fall. Cuirass +2-->
+		<item offset="37" id="23204" />	<!--Fall. Fin. Gaunt. +2-->
+		<item offset="38" id="23271" />	<!--Fall. Flanchard +2-->
+		<item offset="39" id="23338" />	<!--Fall. Sollerets +2-->
+		<item offset="40" id="23071" />	<!--Ankusa Helm +2-->
+		<item offset="41" id="23138" />	<!--An. Jackcoat +2-->
+		<item offset="42" id="23205" />	<!--Ankusa Gloves +2-->
+		<item offset="43" id="23272" />	<!--Ankusa Trousers +2-->
+		<item offset="44" id="23339" />	<!--Ankusa Gaiters +2-->
+		<item offset="45" id="23072" />	<!--Bihu Roundlet +2-->
+		<item offset="46" id="23139" />	<!--Bihu Jstcorps. +2-->
+		<item offset="47" id="23206" />	<!--Bihu Cuffs +2-->
+		<item offset="48" id="23273" />	<!--Bihu Cannions +2-->
+		<item offset="49" id="23340" />	<!--Bihu Slippers +2-->
+		<item offset="50" id="23073" />	<!--Arcadian Beret +2-->
+		<item offset="51" id="23140" />	<!--Arc. Jerkin +2-->
+		<item offset="52" id="23207" />	<!--Arc. Bracers +2-->
+		<item offset="53" id="23274" />	<!--Arc. Braccae +2-->
+		<item offset="54" id="23341" />	<!--Arcadian Socks +2-->
+		<item offset="55" id="23074" />	<!--Sakonji Kabuto +2-->
+		<item offset="56" id="23141" />	<!--Sakonji Domaru +2-->
+		<item offset="57" id="23208" />	<!--Sakonji Kote +2-->
+		<item offset="58" id="23275" />	<!--Sakonji Haidate +2-->
+		<item offset="59" id="23342" />	<!--Sak. Sune-Ate +2-->
+		<item offset="60" id="23075" />	<!--Mochi. Hatsuburi +2-->
+		<item offset="61" id="23142" />	<!--Mochi. Chainmail +2-->
+		<item offset="62" id="23209" />	<!--Mochizuki Tekko +2-->
+		<item offset="63" id="23276" />	<!--Mochi. Hakama +2-->
+		<item offset="64" id="23343" />	<!--Mochi. Kyahan +2-->
+		<item offset="65" id="23076" />	<!--Ptero. Armet +2-->
+		<item offset="66" id="23143" />	<!--Ptero. Mail +2-->
+		<item offset="67" id="23210" />	<!--Ptero. Fin. G. +2-->
+		<item offset="68" id="23277" />	<!--Ptero. Brais +2-->
+		<item offset="69" id="23344" />	<!--Ptero. Greaves +2-->
+		<item offset="70" id="23077" />	<!--Glyphic Horn +2-->
+		<item offset="71" id="23144" />	<!--Glyphic Doublet +2-->
+		<item offset="72" id="23211" />	<!--Glyphic Bracers +2-->
+		<item offset="73" id="23278" />	<!--Glyphic Spats +2-->
+		<item offset="74" id="23345" />	<!--Glyph. Pigaches +2-->
+		<item offset="75" id="23078" />	<!--Luh. Keffiyeh +2-->
+		<item offset="76" id="23145" />	<!--Luhlaza Jubbah +2-->
+		<item offset="77" id="23212" />	<!--Luh. Bazubands +2-->
+		<item offset="78" id="23279" />	<!--Luhlaza Shalwar +2-->
+		<item offset="79" id="23346" />	<!--Luhlaza Charuqs +2-->
+		<item offset="80" id="23079" />	<!--Lanun Tricorne +2-->
+		<item offset="81" id="23146" />	<!--Lanun Frac +2-->
+		<item offset="82" id="23213" />	<!--Lanun Gants +2-->
+		<item offset="83" id="23280" />	<!--Lanun Trews +2-->
+		<item offset="84" id="23347" />	<!--Lanun Bottes +2-->
+		<item offset="85" id="23080" />	<!--Pitre Taj +2-->
+		<item offset="86" id="23147" />	<!--Pitre Tobe +2-->
+		<item offset="87" id="23214" />	<!--Pitre Dastanas +2-->
+		<item offset="88" id="23281" />	<!--Pitre Churidars +2-->
+		<item offset="89" id="23348" />	<!--Pitre Babouches +2-->
+		<item offset="90" id="23081" />	<!--Horos Tiara +2-->
+		<item offset="91" id="23148" />	<!--Horos Casaque +2-->
+		<item offset="92" id="23215" />	<!--Horos Bangles +2-->
+		<item offset="93" id="23282" />	<!--Horos Tights +2-->
+		<item offset="94" id="23349" />	<!--Horos T. Shoes +2-->
+		<item offset="95" id="23082" />	<!--Peda. M.Board +2-->
+		<item offset="96" id="23149" />	<!--Peda. Gown +2-->
+		<item offset="97" id="23216" />	<!--Peda. Bracers +2-->
+		<item offset="98" id="23283" />	<!--Peda. Pants +2-->
+		<item offset="99" id="23350" />	<!--Peda. Loafers +2-->
+		<item offset="100" id="23083" />	<!--Bagua Galero +2-->
+		<item offset="101" id="23150" />	<!--Bagua Tunic +2-->
+		<item offset="102" id="23217" />	<!--Bagua Mitaines +2-->
+		<item offset="103" id="23284" />	<!--Bagua Pants +2-->
+		<item offset="104" id="23351" />	<!--Bagua Sandals +2-->
+		<item offset="105" id="23084" />	<!--Fu. Bandeau +2-->
+		<item offset="106" id="23151" />	<!--Futhark Coat +2-->
+		<item offset="107" id="23218" />	<!--Futhark Mitons +2-->
+		<item offset="108" id="23285" />	<!--Futhark Trousers +2-->
+		<item offset="109" id="23352" />	<!--Futhark Boots +2-->
+	</slip>
+	<slip id="29338">		<!--Storage Slip 27-->
+		<item offset="0" id="23398" />	<!--Agoge Mask +3-->
+		<item offset="1" id="23465" />	<!--Agoge Lorica +3-->
+		<item offset="2" id="23532" />	<!--Agoge Mufflers +3-->
+		<item offset="3" id="23599" />	<!--Agoge Cuisses +3-->
+		<item offset="4" id="23666" />	<!--Agoge Calligae +3-->
+		<item offset="5" id="23399" />	<!--Hes. Crown +3-->
+		<item offset="6" id="23466" />	<!--Hes. Cyclas +3-->
+		<item offset="7" id="23533" />	<!--Hes. Gloves +3-->
+		<item offset="8" id="23600" />	<!--Hes. Hose +3-->
+		<item offset="9" id="23667" />	<!--Hes. Gaiters +3-->
+		<item offset="10" id="23400" />	<!--Piety Cap +3-->
+		<item offset="11" id="23467" />	<!--Piety Bliaut +3-->
+		<item offset="12" id="23534" />	<!--Piety Mitts +3-->
+		<item offset="13" id="23601" />	<!--Piety Pantaln. +3-->
+		<item offset="14" id="23668" />	<!--Piety Duckbills +3-->
+		<item offset="15" id="23401" />	<!--Arch. Petasos +3-->
+		<item offset="16" id="23468" />	<!--Arch. Coat +3-->
+		<item offset="17" id="23535" />	<!--Arch. Gloves +3-->
+		<item offset="18" id="23602" />	<!--Arch. Tonban +3-->
+		<item offset="19" id="23669" />	<!--Arch. Sabots +3-->
+		<item offset="20" id="23402" />	<!--Viti. Chapeau +3-->
+		<item offset="21" id="23469" />	<!--Viti. Tabard +3-->
+		<item offset="22" id="23536" />	<!--Viti. Gloves +3-->
+		<item offset="23" id="23603" />	<!--Viti. Tights +3-->
+		<item offset="24" id="23670" />	<!--Vitiation Boots +3-->
+		<item offset="25" id="23403" />	<!--Plun. Bonnet +3-->
+		<item offset="26" id="23470" />	<!--Plunderer's Vest +3-->
+		<item offset="27" id="23537" />	<!--Plun. Armlets +3-->
+		<item offset="28" id="23604" />	<!--Plun. Culottes +3-->
+		<item offset="29" id="23671" />	<!--Plun. Poulaines +3-->
+		<item offset="30" id="23404" />	<!--Cab. Coronet +3-->
+		<item offset="31" id="23471" />	<!--Cab. Surcoat +3-->
+		<item offset="32" id="23538" />	<!--Cab. Gauntlets +3-->
+		<item offset="33" id="23605" />	<!--Cab. Breeches +3-->
+		<item offset="34" id="23672" />	<!--Cab. Leggings +3-->
+		<item offset="35" id="23405" />	<!--Fall. Burgeonet +3-->
+		<item offset="36" id="23472" />	<!--Fall. Cuirass +3-->
+		<item offset="37" id="23539" />	<!--Fall. Fin. Gaunt. +3-->
+		<item offset="38" id="23606" />	<!--Fall. Flanchard +3-->
+		<item offset="39" id="23673" />	<!--Fall. Sollerets +3-->
+		<item offset="40" id="23406" />	<!--Ankusa Helm +3-->
+		<item offset="41" id="23473" />	<!--An. Jackcoat +3-->
+		<item offset="42" id="23540" />	<!--Ankusa Gloves +3-->
+		<item offset="43" id="23607" />	<!--Ankusa Trousers +3-->
+		<item offset="44" id="23674" />	<!--Ankusa Gaiters +3-->
+		<item offset="45" id="23407" />	<!--Bihu Roundlet +3-->
+		<item offset="46" id="23474" />	<!--Bihu Jstcorps. +3-->
+		<item offset="47" id="23541" />	<!--Bihu Cuffs +3-->
+		<item offset="48" id="23608" />	<!--Bihu Cannions +3-->
+		<item offset="49" id="23675" />	<!--Bihu Slippers +3-->
+		<item offset="50" id="23408" />	<!--Arcadian Beret +3-->
+		<item offset="51" id="23475" />	<!--Arc. Jerkin +3-->
+		<item offset="52" id="23542" />	<!--Arc. Bracers +3-->
+		<item offset="53" id="23609" />	<!--Arc. Braccae +3-->
+		<item offset="54" id="23676" />	<!--Arcadian Socks +3-->
+		<item offset="55" id="23409" />	<!--Sakonji Kabuto +3-->
+		<item offset="56" id="23476" />	<!--Sakonji Domaru +3-->
+		<item offset="57" id="23543" />	<!--Sakonji Kote +3-->
+		<item offset="58" id="23610" />	<!--Sakonji Haidate +3-->
+		<item offset="59" id="23677" />	<!--Sak. Sune-Ate +3-->
+		<item offset="60" id="23410" />	<!--Mochi. Hatsuburi +3-->
+		<item offset="61" id="23477" />	<!--Mochi. Chainmail +3-->
+		<item offset="62" id="23544" />	<!--Mochizuki Tekko +3-->
+		<item offset="63" id="23611" />	<!--Mochi. Hakama +3-->
+		<item offset="64" id="23678" />	<!--Mochi. Kyahan +3-->
+		<item offset="65" id="23411" />	<!--Ptero. Armet +3-->
+		<item offset="66" id="23478" />	<!--Ptero. Mail +3-->
+		<item offset="67" id="23545" />	<!--Ptero. Fin. G. +3-->
+		<item offset="68" id="23612" />	<!--Ptero. Brais +3-->
+		<item offset="69" id="23679" />	<!--Ptero. Greaves +3-->
+		<item offset="70" id="23412" />	<!--Glyphic Horn +3-->
+		<item offset="71" id="23479" />	<!--Glyphic Doublet +3-->
+		<item offset="72" id="23546" />	<!--Glyphic Bracers +3-->
+		<item offset="73" id="23613" />	<!--Glyphic Spats +3-->
+		<item offset="74" id="23680" />	<!--Glyph. Pigaches +3-->
+		<item offset="75" id="23413" />	<!--Luh. Keffiyeh +3-->
+		<item offset="76" id="23480" />	<!--Luhlaza Jubbah +3-->
+		<item offset="77" id="23547" />	<!--Luh. Bazubands +3-->
+		<item offset="78" id="23614" />	<!--Luhlaza Shalwar +3-->
+		<item offset="79" id="23681" />	<!--Luhlaza Charuqs +3-->
+		<item offset="80" id="23414" />	<!--Lanun Tricorne +3-->
+		<item offset="81" id="23481" />	<!--Lanun Frac +3-->
+		<item offset="82" id="23548" />	<!--Lanun Gants +3-->
+		<item offset="83" id="23615" />	<!--Lanun Trews +3-->
+		<item offset="84" id="23682" />	<!--Lanun Bottes +3-->
+		<item offset="85" id="23415" />	<!--Pitre Taj +3-->
+		<item offset="86" id="23482" />	<!--Pitre Tobe +3-->
+		<item offset="87" id="23549" />	<!--Pitre Dastanas +3-->
+		<item offset="88" id="23616" />	<!--Pitre Churidars +3-->
+		<item offset="89" id="23683" />	<!--Pitre Babouches +3-->
+		<item offset="90" id="23416" />	<!--Horos Tiara +3-->
+		<item offset="91" id="23483" />	<!--Horos Casaque +3-->
+		<item offset="92" id="23550" />	<!--Horos Bangles +3-->
+		<item offset="93" id="23617" />	<!--Horos Tights +3-->
+		<item offset="94" id="23684" />	<!--Horos T. Shoes +3-->
+		<item offset="95" id="23417" />	<!--Peda. M.Board +3-->
+		<item offset="96" id="23484" />	<!--Peda. Gown +3-->
+		<item offset="97" id="23551" />	<!--Peda. Bracers +3-->
+		<item offset="98" id="23618" />	<!--Peda. Pants +3-->
+		<item offset="99" id="23685" />	<!--Peda. Loafers +3-->
+		<item offset="100" id="23418" />	<!--Bagua Galero +3-->
+		<item offset="101" id="23485" />	<!--Bagua Tunic +3-->
+		<item offset="102" id="23552" />	<!--Bagua Mitaines +3-->
+		<item offset="103" id="23619" />	<!--Bagua Pants +3-->
+		<item offset="104" id="23686" />	<!--Bagua Sandals +3-->
+		<item offset="105" id="23419" />	<!--Fu. Bandeau +3-->
+		<item offset="106" id="23486" />	<!--Futhark Coat +3-->
+		<item offset="107" id="23553" />	<!--Futhark Mitons +3-->
+		<item offset="108" id="23620" />	<!--Futhark Trousers +3-->
+		<item offset="109" id="23687" />	<!--Futhark Boots +3-->
+	</slip>
+	<slip id="29339">		<!--Storage Slip 28-->
+		<item offset="0" id="21515" />	<!--Tokko Knuckles-->
+		<item offset="1" id="21561" />	<!--Tokko Knife-->
+		<item offset="2" id="21617" />	<!--Tokko Sword-->
+		<item offset="3" id="21670" />	<!--Tokko Claymore-->
+		<item offset="4" id="21718" />	<!--Tokko Axe-->
+		<item offset="5" id="21775" />	<!--Tokko Chopper-->
+		<item offset="6" id="21826" />	<!--Tokko Scythe-->
+		<item offset="7" id="21879" />	<!--Tokko Lance-->
+		<item offset="8" id="21918" />	<!--Tokko Katana-->
+		<item offset="9" id="21971" />	<!--Tokko Tachi-->
+		<item offset="10" id="22027" />	<!--Tokko Rod-->
+		<item offset="11" id="22082" />	<!--Tokko Staff-->
+		<item offset="12" id="22108" />	<!--Tokko Bow-->
+		<item offset="13" id="22214" />	<!--Tokko Grip-->
+		<item offset="14" id="21516" />	<!--Ajja Knuckles-->
+		<item offset="15" id="21562" />	<!--Ajja Knife-->
+		<item offset="16" id="21618" />	<!--Ajja Sword-->
+		<item offset="17" id="21671" />	<!--Ajja Claymore-->
+		<item offset="18" id="21719" />	<!--Ajja Axe-->
+		<item offset="19" id="21776" />	<!--Ajja Chopper-->
+		<item offset="20" id="21827" />	<!--Ajja Scythe-->
+		<item offset="21" id="21880" />	<!--Ajja Lance-->
+		<item offset="22" id="21919" />	<!--Ajja Katana-->
+		<item offset="23" id="21972" />	<!--Ajja Tachi-->
+		<item offset="24" id="22028" />	<!--Ajja Rod-->
+		<item offset="25" id="22083" />	<!--Ajja Staff-->
+		<item offset="26" id="22109" />	<!--Ajja Bow-->
+		<item offset="27" id="22215" />	<!--Ajja Grip-->
+		<item offset="28" id="21517" />	<!--Eletta Knuckles-->
+		<item offset="29" id="21563" />	<!--Eletta Knife-->
+		<item offset="30" id="21619" />	<!--Eletta Sword-->
+		<item offset="31" id="21672" />	<!--Eletta Claymore-->
+		<item offset="32" id="21720" />	<!--Eletta Axe-->
+		<item offset="33" id="21777" />	<!--Eletta Chopper-->
+		<item offset="34" id="21828" />	<!--Eletta Scythe-->
+		<item offset="35" id="21881" />	<!--Eletta Lance-->
+		<item offset="36" id="21920" />	<!--Eletta Katana-->
+		<item offset="37" id="21973" />	<!--Eletta Tachi-->
+		<item offset="38" id="22029" />	<!--Eletta Rod-->
+		<item offset="39" id="22084" />	<!--Eletta Staff-->
+		<item offset="40" id="22110" />	<!--Eletta Bow-->
+		<item offset="41" id="22216" />	<!--Eletta Grip-->
+		<item offset="42" id="21518" />	<!--Kaja Knuckles-->
+		<item offset="43" id="21564" />	<!--Kaja Knife-->
+		<item offset="44" id="21620" />	<!--Kaja Sword-->
+		<item offset="45" id="21673" />	<!--Kaja Claymore-->
+		<item offset="46" id="21721" />	<!--Kaja Axe-->
+		<item offset="47" id="21778" />	<!--Kaja Chopper-->
+		<item offset="48" id="21829" />	<!--Kaja Scythe-->
+		<item offset="49" id="21882" />	<!--Kaja Lance-->
+		<item offset="50" id="21921" />	<!--Kaja Katana-->
+		<item offset="51" id="21974" />	<!--Kaja Tachi-->
+		<item offset="52" id="22030" />	<!--Kaja Rod-->
+		<item offset="53" id="22085" />	<!--Kaja Staff-->
+		<item offset="54" id="22111" />	<!--Kaja Bow-->
+		<item offset="55" id="22217" />	<!--Kaja Grip-->
+		<item offset="56" id="21519" />	<!--Karambit-->
+		<item offset="57" id="21565" />	<!--Tauret-->
+		<item offset="58" id="21621" />	<!--Naegling-->
+		<item offset="59" id="21674" />	<!--Nandaka-->
+		<item offset="60" id="21722" />	<!--Dolichenus-->
+		<item offset="61" id="21779" />	<!--Lycurgos-->
+		<item offset="62" id="21830" />	<!--Drepanum-->
+		<item offset="63" id="21883" />	<!--Shining One-->
+		<item offset="64" id="21922" />	<!--Gokotai-->
+		<item offset="65" id="21975" />	<!--Hachimonji-->
+		<item offset="66" id="22031" />	<!--Maxentius-->
+		<item offset="67" id="22086" />	<!--Xoanon-->
+		<item offset="68" id="22107" />	<!--Ullr-->
+		<item offset="69" id="22218" />	<!--Khonsu-->
+		<item offset="70" id="22089" />	<!--Sophistry-->
+	</slip>
+	<slip id="29340">		<!--Storage Slip 29-->
+		<item offset="0" id="23085" />	<!--Boii Mask +2-->
+		<item offset="1" id="23152" />	<!--Boii Lorica +2-->
+		<item offset="2" id="23219" />	<!--Boii Mufflers +2-->
+		<item offset="3" id="23286" />	<!--Boii Cuisses +2-->
+		<item offset="4" id="23353" />	<!--Boii Calligae +2-->
+		<item offset="5" id="23086" />	<!--Bhikku Crown +2-->
+		<item offset="6" id="23153" />	<!--Bhikku Cyclas +2-->
+		<item offset="7" id="23220" />	<!--Bhikku Gloves +2-->
+		<item offset="8" id="23287" />	<!--Bhikku Hose +2-->
+		<item offset="9" id="23354" />	<!--Bhikku Gaiters +2-->
+		<item offset="10" id="23087" />	<!--Ebers Cap +2-->
+		<item offset="11" id="23154" />	<!--Ebers Bliaut +2-->
+		<item offset="12" id="23221" />	<!--Ebers Mitts +2-->
+		<item offset="13" id="23288" />	<!--Ebers Pant. +2-->
+		<item offset="14" id="23355" />	<!--Ebers Duckbills +2-->
+		<item offset="15" id="23088" />	<!--Wicce Petasos +2-->
+		<item offset="16" id="23155" />	<!--Wicce Coat +2-->
+		<item offset="17" id="23222" />	<!--Wicce Gloves +2-->
+		<item offset="18" id="23289" />	<!--Wicce Chausses +2-->
+		<item offset="19" id="23356" />	<!--Wicce Sabots +2-->
+		<item offset="20" id="23089" />	<!--Leth. Chappel +2-->
+		<item offset="21" id="23156" />	<!--Lethargy Sayon +2-->
+		<item offset="22" id="23223" />	<!--Leth. Ganth. +2-->
+		<item offset="23" id="23290" />	<!--Leth. Fuseau +2-->
+		<item offset="24" id="23357" />	<!--Leth. Houseaux +2-->
+		<item offset="25" id="23090" />	<!--Skulker's Bonnet +2-->
+		<item offset="26" id="23157" />	<!--Skulker's Vest +2-->
+		<item offset="27" id="23224" />	<!--Skulk. Armlets +2-->
+		<item offset="28" id="23291" />	<!--Skulk. Culottes +2-->
+		<item offset="29" id="23358" />	<!--Skulk. Poulaines +2-->
+		<item offset="30" id="23091" />	<!--Chev. Armet +2-->
+		<item offset="31" id="23158" />	<!--Chev. Cuirass +2-->
+		<item offset="32" id="23225" />	<!--Chev. Gauntlets +2-->
+		<item offset="33" id="23292" />	<!--Chev. Cuisses +2-->
+		<item offset="34" id="23359" />	<!--Chev. Sabatons +2-->
+		<item offset="35" id="23092" />	<!--Heath. Burgeon. +2-->
+		<item offset="36" id="23159" />	<!--Heath. Cuirass +2-->
+		<item offset="37" id="23226" />	<!--Heath. Gauntlets +2-->
+		<item offset="38" id="23293" />	<!--Heath. Flanchard +2-->
+		<item offset="39" id="23360" />	<!--Heath. Sollerets +2-->
+		<item offset="40" id="23093" />	<!--Nuk. Cabasset +2-->
+		<item offset="41" id="23160" />	<!--Nukumi Gausape +2-->
+		<item offset="42" id="23227" />	<!--Nukumi Manoplas +2-->
+		<item offset="43" id="23294" />	<!--Nukumi Quijotes +2-->
+		<item offset="44" id="23361" />	<!--Nukumi Ocreae +2-->
+		<item offset="45" id="23094" />	<!--Fili Calot +2-->
+		<item offset="46" id="23161" />	<!--Fili Hongreline +2-->
+		<item offset="47" id="23228" />	<!--Fili Manchettes +2-->
+		<item offset="48" id="23295" />	<!--Fili Rhingrave +2-->
+		<item offset="49" id="23362" />	<!--Fili Cothurnes +2-->
+		<item offset="50" id="23095" />	<!--Amini Gapette +2-->
+		<item offset="51" id="23162" />	<!--Amini Caban +2-->
+		<item offset="52" id="23229" />	<!--Amini Glove. +2-->
+		<item offset="53" id="23296" />	<!--Amini Bragues +2-->
+		<item offset="54" id="23363" />	<!--Amini Bottillons +2-->
+		<item offset="55" id="23096" />	<!--Kasuga Kabuto +2-->
+		<item offset="56" id="23163" />	<!--Kasuga Domaru +2-->
+		<item offset="57" id="23230" />	<!--Kasuga Kote +2-->
+		<item offset="58" id="23297" />	<!--Kasuga Haidate +2-->
+		<item offset="59" id="23364" />	<!--Kas. Sune-Ate +2-->
+		<item offset="60" id="23097" />	<!--Hattori Zukin +2-->
+		<item offset="61" id="23164" />	<!--Hattori Ningi +2-->
+		<item offset="62" id="23231" />	<!--Hattori Tekko +2-->
+		<item offset="63" id="23298" />	<!--Hattori Hakama +2-->
+		<item offset="64" id="23365" />	<!--Hattori Kyahan +2-->
+		<item offset="65" id="23098" />	<!--Peltast's Mezail +2-->
+		<item offset="66" id="23165" />	<!--Pelt. Plackart +2-->
+		<item offset="67" id="23232" />	<!--Pel. Vambraces +2-->
+		<item offset="68" id="23299" />	<!--Pelt. Cuissots +2-->
+		<item offset="69" id="23366" />	<!--Pelt. Schyn. +2-->
+		<item offset="70" id="23099" />	<!--Beckoner's Horn +2-->
+		<item offset="71" id="23166" />	<!--Beck. Doublet +2-->
+		<item offset="72" id="23233" />	<!--Beck. Bracers +2-->
+		<item offset="73" id="23300" />	<!--Beck. Spats +2-->
+		<item offset="74" id="23367" />	<!--Beck. Pigaches +2-->
+		<item offset="75" id="23100" />	<!--Hashishin Kavuk +2-->
+		<item offset="76" id="23167" />	<!--Hashishin Mintan +2-->
+		<item offset="77" id="23234" />	<!--Hashi. Bazu. +2-->
+		<item offset="78" id="23301" />	<!--Hashishin Tayt +2-->
+		<item offset="79" id="23368" />	<!--Hashi. Basmak +2-->
+		<item offset="80" id="23101" />	<!--Chass. Tricorne +2-->
+		<item offset="81" id="23168" />	<!--Chasseur's Frac +2-->
+		<item offset="82" id="23235" />	<!--Chasseur's Gants +2-->
+		<item offset="83" id="23302" />	<!--Chas. Culottes +2-->
+		<item offset="84" id="23369" />	<!--Chass. Bottes +2-->
+		<item offset="85" id="23102" />	<!--Kara. Cappello +2-->
+		<item offset="86" id="23169" />	<!--Kara. Farsetto +2-->
+		<item offset="87" id="23236" />	<!--Karagoz Guanti +2-->
+		<item offset="88" id="23303" />	<!--Kara. Pantaloni +2-->
+		<item offset="89" id="23370" />	<!--Karagoz Scarpe +2-->
+		<item offset="90" id="23103" />	<!--Maculele Tiara +2-->
+		<item offset="91" id="23170" />	<!--Macu. Casaque +2-->
+		<item offset="92" id="23237" />	<!--Macu. Bangles +2-->
+		<item offset="93" id="23304" />	<!--Maculele Tights +2-->
+		<item offset="94" id="23371" />	<!--Macu. Toe Sh. +2-->
+		<item offset="95" id="23104" />	<!--Arbatel Bonnet +2-->
+		<item offset="96" id="23171" />	<!--Arbatel Gown +2-->
+		<item offset="97" id="23238" />	<!--Arbatel Bracers +2-->
+		<item offset="98" id="23305" />	<!--Arbatel Pants +2-->
+		<item offset="99" id="23372" />	<!--Arbatel Loafers +2-->
+		<item offset="100" id="23105" />	<!--Azimuth Hood +2-->
+		<item offset="101" id="23172" />	<!--Azimuth Coat +2-->
+		<item offset="102" id="23239" />	<!--Azimuth Gloves +2-->
+		<item offset="103" id="23306" />	<!--Azimuth Tights +2-->
+		<item offset="104" id="23373" />	<!--Azimuth Gaiters +2-->
+		<item offset="105" id="23106" />	<!--Erilaz Galea +2-->
+		<item offset="106" id="23173" />	<!--Erilaz Surcoat +2-->
+		<item offset="107" id="23240" />	<!--Erilaz Gauntlets +2-->
+		<item offset="108" id="23307" />	<!--Eri. Leg Guards +2-->
+		<item offset="109" id="23374" />	<!--Erilaz Greaves +2-->
+	</slip>
+	<slip id="29341">		<!--Storage Slip 30-->
+		<item offset="0" id="23420" />	<!--Boii Mask +3-->
+		<item offset="1" id="23487" />	<!--Boii Lorica +3-->
+		<item offset="2" id="23554" />	<!--Boii Mufflers +3-->
+		<item offset="3" id="23621" />	<!--Boii Cuisses +3-->
+		<item offset="4" id="23688" />	<!--Boii Calligae +3-->
+		<item offset="5" id="23421" />	<!--Bhikku Crown +3-->
+		<item offset="6" id="23488" />	<!--Bhikku Cyclas +3-->
+		<item offset="7" id="23555" />	<!--Bhikku Gloves +3-->
+		<item offset="8" id="23622" />	<!--Bhikku Hose +3-->
+		<item offset="9" id="23689" />	<!--Bhikku Gaiters +3-->
+		<item offset="10" id="23422" />	<!--Ebers Cap +3-->
+		<item offset="11" id="23489" />	<!--Ebers Bliaut +3-->
+		<item offset="12" id="23556" />	<!--Ebers Mitts +3-->
+		<item offset="13" id="23623" />	<!--Ebers Pant. +3-->
+		<item offset="14" id="23690" />	<!--Ebers Duckbills +3-->
+		<item offset="15" id="23423" />	<!--Wicce Petasos +3-->
+		<item offset="16" id="23490" />	<!--Wicce Coat +3-->
+		<item offset="17" id="23557" />	<!--Wicce Gloves +3-->
+		<item offset="18" id="23624" />	<!--Wicce Chausses +3-->
+		<item offset="19" id="23691" />	<!--Wicce Sabots +3-->
+		<item offset="20" id="23424" />	<!--Leth. Chappel +3-->
+		<item offset="21" id="23491" />	<!--Lethargy Sayon +3-->
+		<item offset="22" id="23558" />	<!--Leth. Ganth. +3-->
+		<item offset="23" id="23625" />	<!--Leth. Fuseau +3-->
+		<item offset="24" id="23692" />	<!--Leth. Houseaux +3-->
+		<item offset="25" id="23425" />	<!--Skulker's Bonnet +3-->
+		<item offset="26" id="23492" />	<!--Skulker's Vest +3-->
+		<item offset="27" id="23559" />	<!--Skulk. Armlets +3-->
+		<item offset="28" id="23626" />	<!--Skulk. Culottes +3-->
+		<item offset="29" id="23693" />	<!--Skulk. Poulaines +3-->
+		<item offset="30" id="23426" />	<!--Chev. Armet +3-->
+		<item offset="31" id="23493" />	<!--Chev. Cuirass +3-->
+		<item offset="32" id="23560" />	<!--Chev. Gauntlets +3-->
+		<item offset="33" id="23627" />	<!--Chev. Cuisses +3-->
+		<item offset="34" id="23694" />	<!--Chev. Sabatons +3-->
+		<item offset="35" id="23427" />	<!--Heath. Bur. +3-->
+		<item offset="36" id="23494" />	<!--Heath. Cuirass +3-->
+		<item offset="37" id="23561" />	<!--Heath. Gauntlets +3-->
+		<item offset="38" id="23628" />	<!--Heath. Flanchard +3-->
+		<item offset="39" id="23695" />	<!--Heath. Sollerets +3-->
+		<item offset="40" id="23428" />	<!--Nuk. Cabasset +3-->
+		<item offset="41" id="23495" />	<!--Nukumi Gausape +3-->
+		<item offset="42" id="23562" />	<!--Nukumi Manoplas +3-->
+		<item offset="43" id="23629" />	<!--Nukumi Quijotes +3-->
+		<item offset="44" id="23696" />	<!--Nukumi Ocreae +3-->
+		<item offset="45" id="23429" />	<!--Fili Calot +3-->
+		<item offset="46" id="23496" />	<!--Fili Hongreline +3-->
+		<item offset="47" id="23563" />	<!--Fili Manchettes +3-->
+		<item offset="48" id="23630" />	<!--Fili Rhingrave +3-->
+		<item offset="49" id="23697" />	<!--Fili Cothurnes +3-->
+		<item offset="50" id="23430" />	<!--Amini Gapette +3-->
+		<item offset="51" id="23497" />	<!--Amini Caban +3-->
+		<item offset="52" id="23564" />	<!--Amini Glove. +3-->
+		<item offset="53" id="23631" />	<!--Amini Bragues +3-->
+		<item offset="54" id="23698" />	<!--Amini Bottillons +3-->
+		<item offset="55" id="23431" />	<!--Kasuga Kabuto +3-->
+		<item offset="56" id="23498" />	<!--Kasuga Domaru +3-->
+		<item offset="57" id="23565" />	<!--Kasuga Kote +3-->
+		<item offset="58" id="23632" />	<!--Kasuga Haidate +3-->
+		<item offset="59" id="23699" />	<!--Kas. Sune-Ate +3-->
+		<item offset="60" id="23432" />	<!--Hattori Zukin +3-->
+		<item offset="61" id="23499" />	<!--Hattori Ningi +3-->
+		<item offset="62" id="23566" />	<!--Hattori Tekko +3-->
+		<item offset="63" id="23633" />	<!--Hattori Hakama +3-->
+		<item offset="64" id="23700" />	<!--Hattori Kyahan +3-->
+		<item offset="65" id="23433" />	<!--Peltast's Mezail +3-->
+		<item offset="66" id="23500" />	<!--Pelt. Plackart +3-->
+		<item offset="67" id="23567" />	<!--Pel. Vambraces +3-->
+		<item offset="68" id="23634" />	<!--Pelt. Cuissots +3-->
+		<item offset="69" id="23701" />	<!--Pelt. Schyn. +3-->
+		<item offset="70" id="23434" />	<!--Beckoner's Horn +3-->
+		<item offset="71" id="23501" />	<!--Beck. Doublet +3-->
+		<item offset="72" id="23568" />	<!--Beck. Bracers +3-->
+		<item offset="73" id="23635" />	<!--Beck. Spats +3-->
+		<item offset="74" id="23702" />	<!--Beck. Pigaches +3-->
+		<item offset="75" id="23435" />	<!--Hashishin Kavuk +3-->
+		<item offset="76" id="23502" />	<!--Hashishin Mintan +3-->
+		<item offset="77" id="23569" />	<!--Hashi. Bazu. +3-->
+		<item offset="78" id="23636" />	<!--Hashishin Tayt +3-->
+		<item offset="79" id="23703" />	<!--Hashi. Basmak +3-->
+		<item offset="80" id="23436" />	<!--Chass. Tricorne +3-->
+		<item offset="81" id="23503" />	<!--Chasseur's Frac +3-->
+		<item offset="82" id="23570" />	<!--Chasseur's Gants +3-->
+		<item offset="83" id="23637" />	<!--Chas. Culottes +3-->
+		<item offset="84" id="23704" />	<!--Chass. Bottes +3-->
+		<item offset="85" id="23437" />	<!--Kara. Cappello +3-->
+		<item offset="86" id="23504" />	<!--Kara. Farsetto +3-->
+		<item offset="87" id="23571" />	<!--Karagoz Guanti +3-->
+		<item offset="88" id="23638" />	<!--Kara. Pantaloni +3-->
+		<item offset="89" id="23705" />	<!--Karagoz Scarpe +3-->
+		<item offset="90" id="23438" />	<!--Maculele Tiara +3-->
+		<item offset="91" id="23505" />	<!--Macu. Casaque +3-->
+		<item offset="92" id="23572" />	<!--Macu. Bangles +3-->
+		<item offset="93" id="23639" />	<!--Maculele Tights +3-->
+		<item offset="94" id="23706" />	<!--Macu. Toe Sh. +3-->
+		<item offset="95" id="23439" />	<!--Arbatel Bonnet +3-->
+		<item offset="96" id="23506" />	<!--Arbatel Gown +3-->
+		<item offset="97" id="23573" />	<!--Arbatel Bracers +3-->
+		<item offset="98" id="23640" />	<!--Arbatel Pants +3-->
+		<item offset="99" id="23707" />	<!--Arbatel Loafers +3-->
+		<item offset="100" id="23440" />	<!--Azimuth Hood +3-->
+		<item offset="101" id="23507" />	<!--Azimuth Coat +3-->
+		<item offset="102" id="23574" />	<!--Azimuth Gloves +3-->
+		<item offset="103" id="23641" />	<!--Azimuth Tights +3-->
+		<item offset="104" id="23708" />	<!--Azimuth Gaiters +3-->
+		<item offset="105" id="23441" />	<!--Erilaz Galea +3-->
+		<item offset="106" id="23508" />	<!--Erilaz Surcoat +3-->
+		<item offset="107" id="23575" />	<!--Erilaz Gauntlets +3-->
+		<item offset="108" id="23642" />	<!--Eri. Leg Guards +3-->
+		<item offset="109" id="23709" />	<!--Erilaz Greaves +3-->
+	</slip>
+	<slip id="29342">		<!--Storage Slip 31-->
+		<item offset="0" id="23812" />	<!--Sapphire Mask-->
+		<item offset="1" id="23813" />	<!--Sapphire Platemail-->
+		<item offset="2" id="23814" />	<!--Sapphire Gauntlets-->
+		<item offset="3" id="23815" />	<!--Sapphire Trousers-->
+		<item offset="4" id="23816" />	<!--Sapphire Leggings-->
+		<item offset="5" id="23817" />	<!--Jadeite Visor-->
+		<item offset="6" id="23818" />	<!--Jadeite Cuirie-->
+		<item offset="7" id="23819" />	<!--Jadeite Gloves-->
+		<item offset="8" id="23820" />	<!--Jadeite Chausses-->
+		<item offset="9" id="23821" />	<!--Jadeite Jambeaux-->
+		<item offset="10" id="23832" />	<!--Ruby Coronal-->
+		<item offset="11" id="23833" />	<!--Ruby Robe-->
+		<item offset="12" id="23834" />	<!--Ruby Cuffs-->
+		<item offset="13" id="23835" />	<!--Ruby Slops-->
+		<item offset="14" id="23836" />	<!--Ruby Pigaches-->
+		<item offset="15" id="23822" />	<!--Diamond Somen-->
+		<item offset="16" id="23823" />	<!--Diamond Haramaki-->
+		<item offset="17" id="23824" />	<!--Diamond Kote-->
+		<item offset="18" id="23825" />	<!--Diamond Hiza.-->
+		<item offset="19" id="23826" />	<!--Diamond Sune-Ate-->
+		<item offset="20" id="23827" />	<!--Emerald Tiara-->
+		<item offset="21" id="23828" />	<!--Emerald Jubbah-->
+		<item offset="22" id="23829" />	<!--Emerald Dastanas-->
+		<item offset="23" id="23830" />	<!--Emerald Shalwar-->
+		<item offset="24" id="23831" />	<!--Emerald Crackows-->
+		<item offset="25" id="23856" />	<!--Arrogance Crown-->
+		<item offset="26" id="23857" />	<!--Arrogance Plate-->
+		<item offset="27" id="23858" />	<!--Arrogance Gaunt.-->
+		<item offset="28" id="23859" />	<!--Arrogance Brais-->
+		<item offset="29" id="23860" />	<!--Arrogance Sabatons-->
+		<item offset="30" id="23837" />	<!--Apathy Mask-->
+		<item offset="31" id="23838" />	<!--Apathy Platemail-->
+		<item offset="32" id="23839" />	<!--Apathy Gauntlets-->
+		<item offset="33" id="23840" />	<!--Apathy Brais-->
+		<item offset="34" id="23841" />	<!--Apathy Sabatons-->
+		<item offset="35" id="23842" />	<!--Rage Platemail-->
+		<item offset="36" id="23843" />	<!--Rage Gauntlets-->
+		<item offset="37" id="23844" />	<!--Rage Brais-->
+		<item offset="38" id="23845" />	<!--Rage Sabatons-->
+		<item offset="39" id="23846" />	<!--Cowardice Petasos-->
+		<item offset="40" id="23847" />	<!--Cowardice Coat-->
+		<item offset="41" id="23848" />	<!--Cowardice Gloves-->
+		<item offset="42" id="23849" />	<!--Cowardice Tonban-->
+		<item offset="43" id="23850" />	<!--Cowardice Sabots-->
+		<item offset="44" id="23851" />	<!--Envy Crown-->
+		<item offset="45" id="23852" />	<!--Envy Cyclas-->
+		<item offset="46" id="23853" />	<!--Envy Gauntlets-->
+		<item offset="47" id="23854" />	<!--Envy Flanchard-->
+		<item offset="48" id="23855" />	<!--Envy Sollerets-->
+		<item offset="49" id="23894" />	<!--Prishe's Boots-->
+		<item offset="50" id="24271" />	<!--Prishe's Boots +1-->
+		<item offset="51" id="22003" />	<!--Arthro's Scepter-->
+	</slip>
+	<slip id="29343">		<!--Storage Slip 32-->
+		<item offset="0" id="23895" />	<!--Pumm. Mask +4-->
+		<item offset="1" id="23940" />	<!--Pumm. Lorica +4-->
+		<item offset="2" id="23985" />	<!--Pumm. Mufflers +4-->
+		<item offset="3" id="24030" />	<!--Pumm. Cuisses +4-->
+		<item offset="4" id="24075" />	<!--Pumm. Calligae +4-->
+		<item offset="5" id="23896" />	<!--Anchor. Crown +4-->
+		<item offset="6" id="23941" />	<!--Anch. Cyclas +4-->
+		<item offset="7" id="23986" />	<!--Anch. Gloves +4-->
+		<item offset="8" id="24031" />	<!--Anch. Hose +4-->
+		<item offset="9" id="24076" />	<!--Anch. Gaiters +4-->
+		<item offset="10" id="23897" />	<!--Theo. Cap +4-->
+		<item offset="11" id="23942" />	<!--Theo. Bliaut +4-->
+		<item offset="12" id="23987" />	<!--Theo. Mitts +4-->
+		<item offset="13" id="24032" />	<!--Theo. Pant. +4-->
+		<item offset="14" id="24077" />	<!--Theo. Duckbills +4-->
+		<item offset="15" id="23898" />	<!--Spae. Petasos +4-->
+		<item offset="16" id="23943" />	<!--Spae. Coat +4-->
+		<item offset="17" id="23988" />	<!--Spae. Gloves +4-->
+		<item offset="18" id="24033" />	<!--Spae. Tonban +4-->
+		<item offset="19" id="24078" />	<!--Spae. Sabots +4-->
+		<item offset="20" id="23899" />	<!--Atro. Chapeau +4-->
+		<item offset="21" id="23944" />	<!--Atrophy Tabard +4-->
+		<item offset="22" id="23989" />	<!--Atro. Gloves +4-->
+		<item offset="23" id="24034" />	<!--Atro. Tights +4-->
+		<item offset="24" id="24079" />	<!--Atro. Boots +4-->
+		<item offset="25" id="23900" />	<!--Pill. Bonnet +4-->
+		<item offset="26" id="23945" />	<!--Pill. Vest +4-->
+		<item offset="27" id="23990" />	<!--Pill. Armlets +4-->
+		<item offset="28" id="24035" />	<!--Pill. Culottes +4-->
+		<item offset="29" id="24080" />	<!--Pill. Poulaines +4-->
+		<item offset="30" id="23901" />	<!--Rev. Coronet +4-->
+		<item offset="31" id="23946" />	<!--Rev. Surcoat +4-->
+		<item offset="32" id="23991" />	<!--Rav. Gauntlets +4-->
+		<item offset="33" id="24036" />	<!--Rev. Breeches +4-->
+		<item offset="34" id="24081" />	<!--Rev. Leggings +4-->
+		<item offset="35" id="23902" />	<!--Ig. Burgeonet +4-->
+		<item offset="36" id="23947" />	<!--Ig. Cuirass +4-->
+		<item offset="37" id="23992" />	<!--Ig. Fin. Gaunt. +4-->
+		<item offset="38" id="24037" />	<!--Ig. Flanchard +4-->
+		<item offset="39" id="24082" />	<!--Ig. Sollerets +4-->
+		<item offset="40" id="23903" />	<!--Totemic Helm +4-->
+		<item offset="41" id="23948" />	<!--Tot. Jackcoat +4-->
+		<item offset="42" id="23993" />	<!--Tot. Gloves +4-->
+		<item offset="43" id="24038" />	<!--Tot. Trousers +4-->
+		<item offset="44" id="24083" />	<!--Tot. Gaiters +4-->
+		<item offset="45" id="23904" />	<!--Brioso Roundlet +4-->
+		<item offset="46" id="23949" />	<!--Brioso Just. +4-->
+		<item offset="47" id="23994" />	<!--Brioso Cuffs +4-->
+		<item offset="48" id="24039" />	<!--Brios. Cann. +4-->
+		<item offset="49" id="24084" />	<!--Brioso Slippers +4-->
+		<item offset="50" id="23905" />	<!--Orion Beret +4-->
+		<item offset="51" id="23950" />	<!--Orion Jerkin +4-->
+		<item offset="52" id="23995" />	<!--Orion Bracers +4-->
+		<item offset="53" id="24040" />	<!--Orion Braccae +4-->
+		<item offset="54" id="24085" />	<!--Orion Socks +4-->
+		<item offset="55" id="23906" />	<!--Wakido Kabuto +4-->
+		<item offset="56" id="23951" />	<!--Wakido Domaru +4-->
+		<item offset="57" id="23996" />	<!--Wakido Kote +4-->
+		<item offset="58" id="24041" />	<!--Wakido Haidate +4-->
+		<item offset="59" id="24086" />	<!--Wakido Sune. +4-->
+		<item offset="60" id="23907" />	<!--Hachi. Hatsu. +4-->
+		<item offset="61" id="23952" />	<!--Hachi. Chain. +4-->
+		<item offset="62" id="23997" />	<!--Hachiya Tekko +4-->
+		<item offset="63" id="24042" />	<!--Hachiya Hakama +4-->
+		<item offset="64" id="24087" />	<!--Hachiya Kyahan +4-->
+		<item offset="65" id="23908" />	<!--Vishap Armet +4-->
+		<item offset="66" id="23953" />	<!--Vishap Mail +4-->
+		<item offset="67" id="23998" />	<!--Vish. Fin. +4-->
+		<item offset="68" id="24043" />	<!--Vishap Brais +4-->
+		<item offset="69" id="24088" />	<!--Vishap Greaves +4-->
+		<item offset="70" id="23909" />	<!--Con. Horn +4-->
+		<item offset="71" id="23954" />	<!--Con. Doublet +4-->
+		<item offset="72" id="23999" />	<!--Con. Bracers +4-->
+		<item offset="73" id="24044" />	<!--Con. Spats +4-->
+		<item offset="74" id="24089" />	<!--Con. Pigaches +4-->
+		<item offset="75" id="23910" />	<!--Assim. Keffiyeh +4-->
+		<item offset="76" id="23955" />	<!--Assim. Jubbah +4-->
+		<item offset="77" id="24000" />	<!--Assim. Bazu. +4-->
+		<item offset="78" id="24045" />	<!--Assim. Shalwar +4-->
+		<item offset="79" id="24090" />	<!--Assim. Charuqs +4-->
+		<item offset="80" id="23911" />	<!--Laksa. Tricorne +4-->
+		<item offset="81" id="23956" />	<!--Laksa. Frac +4-->
+		<item offset="82" id="24001" />	<!--Lak. Gants +4-->
+		<item offset="83" id="24046" />	<!--Laksa. Trews +4-->
+		<item offset="84" id="24091" />	<!--Laksa. Bottes +4-->
+		<item offset="85" id="23912" />	<!--Foire Taj +4-->
+		<item offset="86" id="23957" />	<!--Foire Tobe +4-->
+		<item offset="87" id="24002" />	<!--Foire Dastanas +4-->
+		<item offset="88" id="24047" />	<!--Foire Churidars +4-->
+		<item offset="89" id="24092" />	<!--Foire Babouches +4-->
+		<item offset="90" id="23913" />	<!--Maxixi Tiara +4-->
+		<item offset="91" id="23958" />	<!--Maxixi Casaque +4-->
+		<item offset="92" id="24003" />	<!--Maxixi Bangles +4-->
+		<item offset="93" id="24048" />	<!--Maxixi Tights +4-->
+		<item offset="94" id="24093" />	<!--Maxixi Toe Sh. +4-->
+		<item offset="95" id="23914" />	<!--Maxixi Tiara +4-->
+		<item offset="96" id="23959" />	<!--Maxixi Casaque +4-->
+		<item offset="97" id="24004" />	<!--Maxixi Bangles +4-->
+		<item offset="98" id="24049" />	<!--Maxixi Tights +4-->
+		<item offset="99" id="24094" />	<!--Maxixi Toe Sh. +4-->
+		<item offset="100" id="23915" />	<!--Acad. Mortar. +4-->
+		<item offset="101" id="23960" />	<!--Acad. Gown +4-->
+		<item offset="102" id="24005" />	<!--Acad. Bracers +4-->
+		<item offset="103" id="24050" />	<!--Acad. Pants +4-->
+		<item offset="104" id="24095" />	<!--Acad. Loafers +4-->
+		<item offset="105" id="23916" />	<!--Geo. Galero +4-->
+		<item offset="106" id="23961" />	<!--Geo. Tunic +4-->
+		<item offset="107" id="24006" />	<!--Geo. Mitaines +4-->
+		<item offset="108" id="24051" />	<!--Geo. Pants +4-->
+		<item offset="109" id="24096" />	<!--Geo. Sandals +4-->
+		<item offset="110" id="23917" />	<!--Runeist Bandeau +4-->
+		<item offset="111" id="23962" />	<!--Runeist Coat +4-->
+		<item offset="112" id="24007" />	<!--Rune. Mitons +4-->
+		<item offset="113" id="24052" />	<!--Rune. Trousers +4-->
+		<item offset="114" id="24097" />	<!--Runeist Boots +4-->
+	</slip>
+	<slip id="29344">		<!--Storage Slip 33-->
+		<item offset="0" id="23918" />	<!--Agoge Mask +4-->
+		<item offset="1" id="23963" />	<!--Agoge Lorica +4-->
+		<item offset="2" id="24008" />	<!--Agoge Mufflers +4-->
+		<item offset="3" id="24053" />	<!--Agoge Cuisses +4-->
+		<item offset="4" id="24098" />	<!--Agoge Calligae +4-->
+		<item offset="5" id="23919" />	<!--Hes. Crown +4-->
+		<item offset="6" id="23964" />	<!--Hesy. Cyclas +4-->
+		<item offset="7" id="24009" />	<!--Hesy. Gloves +4-->
+		<item offset="8" id="24054" />	<!--Hesy. Hose +4-->
+		<item offset="9" id="24099" />	<!--Hesy. Gaiters +4-->
+		<item offset="10" id="23920" />	<!--Piety Cap +4-->
+		<item offset="11" id="23965" />	<!--Piety Bliaut +4-->
+		<item offset="12" id="24010" />	<!--Piety Mitts +4-->
+		<item offset="13" id="24055" />	<!--Piety Panta. +4-->
+		<item offset="14" id="24100" />	<!--Piety Duckbills +4-->
+		<item offset="15" id="23921" />	<!--Arch. Petasos +4-->
+		<item offset="16" id="23966" />	<!--Arch. Coat +4-->
+		<item offset="17" id="24011" />	<!--Arch. Gloves +4-->
+		<item offset="18" id="24056" />	<!--Arch. Tonban +4-->
+		<item offset="19" id="24101" />	<!--Arch. Sabots +4-->
+		<item offset="20" id="23922" />	<!--Viti. Chapeau +4-->
+		<item offset="21" id="23967" />	<!--Viti. Tabard +4-->
+		<item offset="22" id="24012" />	<!--Viti. Gloves +4-->
+		<item offset="23" id="24057" />	<!--Viti. Tights +4-->
+		<item offset="24" id="24102" />	<!--Viti. Boots +4-->
+		<item offset="25" id="23923" />	<!--Plun. Bonnet +4-->
+		<item offset="26" id="23968" />	<!--Plunderer's Vest +4-->
+		<item offset="27" id="24013" />	<!--Plun. Armlets +4-->
+		<item offset="28" id="24058" />	<!--Plun. Culottes +4-->
+		<item offset="29" id="24103" />	<!--Plun. Poulaines +4-->
+		<item offset="30" id="23924" />	<!--Cab. Coronet +4-->
+		<item offset="31" id="23969" />	<!--Cab. Surcoat +4-->
+		<item offset="32" id="24014" />	<!--Cab. Gauntlets +4-->
+		<item offset="33" id="24059" />	<!--Cab. Breeches +4-->
+		<item offset="34" id="24104" />	<!--Cab. Leggings +4-->
+		<item offset="35" id="23925" />	<!--Fall. Burgeonet +4-->
+		<item offset="36" id="23970" />	<!--Fall. Cuirass +4-->
+		<item offset="37" id="24015" />	<!--Fall. Fin. Gaunt. +4-->
+		<item offset="38" id="24060" />	<!--Fall. Flanchard +4-->
+		<item offset="39" id="24105" />	<!--Fallen's So. +4-->
+		<item offset="40" id="23926" />	<!--Ankusa Helm +4-->
+		<item offset="41" id="23971" />	<!--An. Jackcoat +4-->
+		<item offset="42" id="24016" />	<!--Ankusa Gloves +4-->
+		<item offset="43" id="24061" />	<!--An. Trousers +4-->
+		<item offset="44" id="24106" />	<!--Ankusa Gaiters +4-->
+		<item offset="45" id="23927" />	<!--Bihu Roundlet +4-->
+		<item offset="46" id="23972" />	<!--Bihu Just. +4-->
+		<item offset="47" id="24017" />	<!--Bihu Cuffs +4-->
+		<item offset="48" id="24062" />	<!--Bihu Cann. +4-->
+		<item offset="49" id="24107" />	<!--Bihu Slippers +4-->
+		<item offset="50" id="23928" />	<!--Arcadian Beret +4-->
+		<item offset="51" id="23973" />	<!--Arc. Jerkin +4-->
+		<item offset="52" id="24018" />	<!--Arc. Bracers +4-->
+		<item offset="53" id="24063" />	<!--Arc. Braccae +4-->
+		<item offset="54" id="24108" />	<!--Arc. Socks +4-->
+		<item offset="55" id="23929" />	<!--Sakonji Kabuto +4-->
+		<item offset="56" id="23974" />	<!--Sakonji Do. +4-->
+		<item offset="57" id="24019" />	<!--Sakonji Kote +4-->
+		<item offset="58" id="24064" />	<!--Sakonji Haidate +4-->
+		<item offset="59" id="24109" />	<!--Sakonji Sune. +4-->
+		<item offset="60" id="23930" />	<!--Mochi. Hatsu. +4-->
+		<item offset="61" id="23975" />	<!--Mochi. Chainmail +4-->
+		<item offset="62" id="24020" />	<!--Mochi. Tekko +4-->
+		<item offset="63" id="24065" />	<!--Mochi. Hakama +4-->
+		<item offset="64" id="24110" />	<!--Mochi. Kyahan +4-->
+		<item offset="65" id="23931" />	<!--Ptero. Armet +4-->
+		<item offset="66" id="23976" />	<!--Ptero. Mail +4-->
+		<item offset="67" id="24021" />	<!--Ptero. Fin. G. +4-->
+		<item offset="68" id="24066" />	<!--Ptero. Brais +4-->
+		<item offset="69" id="24111" />	<!--Ptero. Greaves +4-->
+		<item offset="70" id="23932" />	<!--Glyphic Horn +4-->
+		<item offset="71" id="23977" />	<!--Glyphic Doublet +4-->
+		<item offset="72" id="24022" />	<!--Glyph. Bracers +4-->
+		<item offset="73" id="24067" />	<!--Glyph. Spats +4-->
+		<item offset="74" id="24112" />	<!--Glyph. Pigaches +4-->
+		<item offset="75" id="23933" />	<!--Luhlaza Keffiyeh +4-->
+		<item offset="76" id="23978" />	<!--Luhlaza Jubbah +4-->
+		<item offset="77" id="24023" />	<!--Luh. Bazu. +4-->
+		<item offset="78" id="24068" />	<!--Luh. Shalwar +4-->
+		<item offset="79" id="24113" />	<!--Luhlaza Ch. +4-->
+		<item offset="80" id="23934" />	<!--Lanun Tricorne +4-->
+		<item offset="81" id="23979" />	<!--Lanun Frac +4-->
+		<item offset="82" id="24024" />	<!--Lanun Gants +4-->
+		<item offset="83" id="24069" />	<!--Lanun Trews +4-->
+		<item offset="84" id="24114" />	<!--Lanun Bottes +4-->
+		<item offset="85" id="23935" />	<!--Pitre Taj +4-->
+		<item offset="86" id="23980" />	<!--Pitre Tobe +4-->
+		<item offset="87" id="24025" />	<!--Pitre Dastanas +4-->
+		<item offset="88" id="24070" />	<!--Pitre Churidars +4-->
+		<item offset="89" id="24115" />	<!--Pitre Babouches +4-->
+		<item offset="90" id="23936" />	<!--Horos Tiara +4-->
+		<item offset="91" id="23981" />	<!--Horos Casaque +4-->
+		<item offset="92" id="24026" />	<!--Horos Bangles +4-->
+		<item offset="93" id="24071" />	<!--Horos Tights +4-->
+		<item offset="94" id="24116" />	<!--Horos Toe Sh. +4-->
+		<item offset="95" id="23937" />	<!--Peda. Mortar. +4-->
+		<item offset="96" id="23982" />	<!--Peda. Gown +4-->
+		<item offset="97" id="24027" />	<!--Peda. Bracers +4-->
+		<item offset="98" id="24072" />	<!--Peda. Pants +4-->
+		<item offset="99" id="24117" />	<!--Peda. Loafers +4-->
+		<item offset="100" id="23938" />	<!--Bagua Galero +4-->
+		<item offset="101" id="23983" />	<!--Bagua Tunic +4-->
+		<item offset="102" id="24028" />	<!--Bagua Mitaines +4-->
+		<item offset="103" id="24073" />	<!--Bagua Pants +4-->
+		<item offset="104" id="24118" />	<!--Bagua Sandals +4-->
+		<item offset="105" id="23939" />	<!--Fu. Bandeau +4-->
+		<item offset="106" id="23984" />	<!--Futhark Coat +4-->
+		<item offset="107" id="24029" />	<!--Futhark Mitons +4-->
+		<item offset="108" id="24074" />	<!--Futh. Trousers +4-->
+		<item offset="109" id="24119" />	<!--Futh. Boots +4-->
+	</slip>
 </slips>


### PR DESCRIPTION
HTML Report of WinMerge comparison. I also compiled this in VS2022 until I realized that's not needed. 

Comparison of slips.xml (old version) vs slips_test.txt (new version)
[FindAll_slipsXML_diff_20251010.htm](https://github.com/user-attachments/files/22859401/FindAll_slipsXML_diff_20251010.htm)
